### PR TITLE
Change context parameter from `env` to `envType`

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ npm run deploy:prod -- --context vpcCidr=10.5.0.0/20
 
 # Use single NAT gateway instead of redundant setup for cost savings
 npm run deploy:prod -- --context enableRedundantNatGateways=false
+
+# Deploy with explicit environment type
+npx cdk deploy --context envType=dev-test
+npx cdk deploy --context envType=prod
 ```
 
 ## 📚 Documentation

--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -8,7 +8,7 @@ import { generateStandardTags } from '../lib/utils/tag-helpers';
 const app = new cdk.App();
 
 // Get environment from context (defaults to dev-test)
-const envName = app.node.tryGetContext('env') || 'dev-test';
+const envName = app.node.tryGetContext('envType') || 'dev-test';
 
 // Get the environment configuration from context
 // CDK automatically handles context overrides via --context flag
@@ -20,8 +20,8 @@ if (!envConfig) {
 ❌ Environment configuration for '${envName}' not found in cdk.json
 
 Usage:
-  npx cdk deploy --context env=dev-test
-  npx cdk deploy --context env=prod
+  npx cdk deploy --context envType=dev-test
+  npx cdk deploy --context envType=prod
 
 Expected cdk.json structure:
 {


### PR DESCRIPTION
# Change context parameter from `env` to `envType`

## Summary
Updates the CDK context parameter from `--context env=` to `--context envType=` for consistency with other stack implementations in the TAK infrastructure.

## Changes
- Changed context parameter lookup from `'env'` to `'envType'` in `bin/cdk.ts`
- Updated error message usage examples
- Added documentation examples in README.md

## Breaking Change
⚠️ **This is a breaking change for deployment commands:**

**Before:**
```bash
npx cdk deploy --context env=dev-test
npx cdk deploy --context env=prod
