### PR TITLE
Add S3 Bucket for TAK Server Images

### DIFF
--- a/lib/base-infra-stack.ts
+++ b/lib/base-infra-stack.ts
@@ -48,7 +48,7 @@ export class BaseInfraStack extends cdk.Stack {
     const { vpc, ipv6CidrBlock, vpcLogicalId } = createVpcL2Resources(this, vpcCidr, enableRedundantNatGateways);
     const { ecsCluster } = createEcsResources(this, this.stackName, vpc);
     const { kmsKey, kmsAlias } = createKmsResources(this, this.stackName, enableKeyRotation, removalPolicy);
-    const { configBucket } = createS3Resources(this, this.stackName, cdk.Stack.of(this).region, kmsKey, enableVersioning, removalPolicy);
+    const { configBucket, appImagesBucket } = createS3Resources(this, this.stackName, cdk.Stack.of(this).region, kmsKey, enableVersioning, removalPolicy);
 
     // Endpoint Security Group (for interface endpoints)
     let endpointSg: ec2.SecurityGroup | undefined = undefined;
@@ -91,6 +91,7 @@ export class BaseInfraStack extends cdk.Stack {
       kmsKey,
       kmsAlias,
       configBucket,
+      appImagesBucket,
       vpcEndpoints,
       certificate,
       hostedZone,

--- a/lib/constructs/services.ts
+++ b/lib/constructs/services.ts
@@ -51,5 +51,18 @@ export function createS3Resources(scope: Construct, stackName: string, region: s
     removalPolicy: removalPolicy === 'RETAIN' ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY,
     objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_ENFORCED,
   });
-  return { configBucket };
+
+  const appImagesBucket = new s3.Bucket(scope, 'AppImagesBucket', {
+    bucketName: `${stackName.toLowerCase()}-${region}-app-images`,
+    encryption: s3.BucketEncryption.KMS,
+    encryptionKey: kmsKey,
+    bucketKeyEnabled: true,
+    enforceSSL: true,
+    blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+    versioned: enableVersioning,
+    removalPolicy: removalPolicy === 'RETAIN' ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY,
+    objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_ENFORCED,
+  });
+
+  return { configBucket, appImagesBucket };
 }

--- a/lib/outputs.ts
+++ b/lib/outputs.ts
@@ -18,6 +18,7 @@ export interface OutputParams {
   kmsKey: kms.Key;
   kmsAlias: kms.Alias;
   configBucket: s3.Bucket;
+  appImagesBucket: s3.Bucket;
   vpcEndpoints?: Record<string, ec2.GatewayVpcEndpoint | ec2.InterfaceVpcEndpoint>;
   certificate?: acm.Certificate;
   hostedZone?: route53.IHostedZone;
@@ -41,6 +42,7 @@ export function registerOutputs(params: OutputParams): void {
     { key: 'KmsKeyArn', value: params.kmsKey.keyArn, description: 'KMS Key ARN' },
     { key: 'KmsAlias', value: params.kmsAlias.aliasName, description: 'KMS Key Alias' },
     { key: 'S3BucketArn', value: params.configBucket.bucketArn, description: 'S3 Configuration Bucket ARN' },
+    { key: 'S3TAKImagesArn', value: params.appImagesBucket.bucketArn, description: 'S3 TAK Images Bucket ARN' },
   ];
 
   outputs.forEach(({ key, value, description }) => {

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -17,7 +17,7 @@ describe('AWS Resources', () => {
     template.resourceCountIs('AWS::ECS::Cluster', 1);
     template.resourceCountIs('AWS::KMS::Key', 1);
     template.resourceCountIs('AWS::KMS::Alias', 1);
-    template.resourceCountIs('AWS::S3::Bucket', 1);
+    template.resourceCountIs('AWS::S3::Bucket', 2);
     template.resourceCountIs('AWS::CertificateManager::Certificate', 1);
     template.hasResourceProperties('AWS::S3::Bucket', {
       OwnershipControls: {


### PR DESCRIPTION
## Add S3 Bucket for TAK Server Images

### Summary
Adds a second S3 bucket to store TAK Server images used for Docker container builds.

### Changes
- **services.ts**: Added `appImagesBucket` with identical configuration to config bucket
- **outputs.ts**: Added `S3TAKImagesArn` export for cross-stack references

### Bucket Configuration
- Naming: `{stackName}-{region}-app-images`
- KMS encryption with existing key
- SSL enforcement and public access blocking
- Versioning enabled (configurable)

### Export Name
`TAK-{EnvName}-BaseInfra-S3TAKImagesArn`
