### PR TITLE
Fix Deployment Workflow Test Dependencies

### DIFF
--- a/.github/workflows/cdk-test.yml
+++ b/.github/workflows/cdk-test.yml
@@ -20,6 +20,7 @@ on:
       - 'docs/**'
       - '*.md'
       - '.gitignore'
+  workflow_call:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Fix Deployment Workflow Test Dependencies

## Problem
The deployment workflow was running in parallel with tests when code was pushed to main, creating a race condition where broken code could be deployed before tests completed or failed.

## Solution
- **Added test job dependency**: Deployment jobs now wait for tests to complete successfully
- **Prevents broken deployments**: Failed tests automatically block deployment
- **Maintains single source of truth**: Uses existing `cdk-test.yml` workflow instead of duplicating test logic

## Changes Made

### Workflow Structure
```yaml
jobs:
  test:
    uses: ./.github/workflows/cdk-test.yml
    if: github.ref == 'refs/heads/main'

  deploy-devtest:
    needs: test  # ← Waits for tests to pass
    
  deploy-production:
    needs: test  # ← Waits for tests to pass
