### PR TITLE
Fix: Add sts:AssumeRole Permission to GitHub Actions Policy

### DIFF
--- a/docs/AWS_GITHUB_SETUP.md
+++ b/docs/AWS_GITHUB_SETUP.md
@@ -220,7 +220,8 @@ cat > tak-github-actions-policy.json << 'EOF'
         "ssm:DeleteParameter",
         "ssm:AddTagsToResource",
         "ssm:RemoveTagsFromResource",
-        "sts:GetCallerIdentity"
+        "sts:GetCallerIdentity",
+        "sts:AssumeRole"
       ],
       "Resource": "*"
     }
@@ -438,7 +439,8 @@ Instead of `PowerUserAccess`, create a comprehensive policy for all TAK infrastr
         "ssm:DeleteParameter",
         "ssm:AddTagsToResource",
         "ssm:RemoveTagsFromResource",
-        "sts:GetCallerIdentity"
+        "sts:GetCallerIdentity",
+        "sts:AssumeRole"
       ],
       "Resource": "*"
     }
@@ -508,6 +510,7 @@ Monitor deployments in:
 - **DNS Propagation:** Allow 24-48 hours for full DNS propagation
 - **CDK Bootstrap:** Each account needs CDK bootstrap before first deployment
 - **ECS Service-Linked Role:** First ECS deployment requires: `aws iam create-service-linked-role --aws-service-name ecs.amazonaws.com`
+- **CDK Role Assumption Warnings:** Messages like "current credentials could not be used to assume 'arn:aws:iam::***:role/cdk-hnb659fds-*-role-***'" are normal. CDK tries to assume specialized roles but falls back to your main role permissions. The `sts:AssumeRole` permission in the policy eliminates these warnings.
 
 **Useful Commands:**
 


### PR DESCRIPTION
# Fix: Add sts:AssumeRole Permission to GitHub Actions Policy

## Problem
CDK deployments were showing warnings about not being able to assume specialized CDK roles (e.g., `cdk-hnb659fds-*-role-*`). While deployments still worked due to fallback permissions, these warnings were confusing.

## Solution
- Added `sts:AssumeRole` permission to the `TAK-GitHub-Actions-Policy`
- Updated both policy definitions in the documentation
- Added explanatory note about CDK role assumption behavior

## Changes
- **docs/AWS_GITHUB_SETUP.md**: Added `sts:AssumeRole` permission to both policy definitions
- **docs/AWS_GITHUB_SETUP.md**: Added troubleshooting note explaining CDK role assumption warnings

## Impact
- Eliminates confusing warning messages during CDK deployments
- No functional changes to deployment behavior
- Improves deployment log clarity

## Testing
- [ ] Verify policy syntax is valid
- [ ] Confirm deployments work without warnings after policy update
