### PR TITLE
Add ECR lifecycle policy for untagged images cleanup

### DIFF
--- a/lib/constructs/services.ts
+++ b/lib/constructs/services.ts
@@ -5,6 +5,7 @@ import * as kms from 'aws-cdk-lib/aws-kms';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import { RemovalPolicy } from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib';
 import { PolicyStatement, Effect, AccountRootPrincipal } from 'aws-cdk-lib/aws-iam';
 
 export function createEcsResources(scope: Construct, stackName: string, vpc: ec2.IVpc) {
@@ -23,6 +24,9 @@ export function createEcrResources(scope: Construct, stackName: string, imageRet
     imageTagMutability: ecr.TagMutability.MUTABLE,
     lifecycleRules: [{
       maxImageCount: imageRetentionCount,
+    }, {
+      tagStatus: ecr.TagStatus.UNTAGGED,
+      maxImageAge: cdk.Duration.days(1),
     }],
     removalPolicy: removalPolicy === 'RETAIN' ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY,
   });


### PR DESCRIPTION
# Add ECR lifecycle policy for untagged images cleanup

## Summary
Restores the ECR lifecycle policy that automatically removes untagged images after 1 day, which was accidentally removed previously.

## Changes
- Added second lifecycle rule to ECR repository configuration
- Targets untagged images with 1-day expiration
- Added required `cdk.Duration` import

## Impact
- Prevents accumulation of untagged images in ECR repositories
- Reduces storage costs by cleaning up build artifacts
- Maintains existing image retention policies (5 images for dev, 20 for prod)

## Testing
- [x] TypeScript compilation passes
- [x] Existing tests pass
- [x] No breaking changes to current functionality
