### PR TITLE
Fix: Context Parameter Parsing Issue

### DIFF
--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -13,7 +13,11 @@ const envName = app.node.tryGetContext('envType') || 'dev-test';
 // Get the environment configuration from context
 // CDK automatically handles context overrides via --context flag
 const envConfig = app.node.tryGetContext(envName);
-const defaults = app.node.tryGetContext('tak-defaults');
+const defaults = {
+  project: app.node.tryGetContext('tak-project') || app.node.tryGetContext('tak-defaults')?.project,
+  component: app.node.tryGetContext('tak-component') || app.node.tryGetContext('tak-defaults')?.component,
+  region: app.node.tryGetContext('tak-region') || app.node.tryGetContext('tak-defaults')?.region
+};
 
 if (!envConfig) {
   throw new Error(`

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -236,10 +236,31 @@ npm run deploy:dev -- --context stackName=FeatureBranch
 
 ### **Resource Tagging**
 All AWS resources are automatically tagged with:
-- **Project**: "TAK" (from `tak-defaults.project`)
-- **Component**: "BaseInfra" (from `tak-defaults.component`)
+- **Project**: "TAK.NZ" (from `tak-defaults.project` or `tak-project` override)
+- **Component**: "BaseInfra" (from `tak-defaults.component` or `tak-component` override)
 - **Environment**: The environment name (from `stackName`)
 - **ManagedBy**: "CDK"
+
+### **Project Configuration Overrides**
+The project metadata can be overridden using individual context parameters:
+
+```bash
+# Override project name for custom branding
+npm run deploy:dev -- --context tak-project="Custom TAK Project"
+
+# Override component name (useful for custom deployments)
+npm run deploy:dev -- --context tak-component="CustomBaseInfra"
+
+# Override region for tagging purposes
+npm run deploy:dev -- --context tak-region="us-east-1"
+```
+
+#### **Project Context Parameters**
+| Parameter | Description | Default | Example Override |
+|-----------|-------------|---------|------------------|
+| `tak-project` | Project name for resource tagging | `TAK.NZ` | `"Enterprise TAK"` |
+| `tak-component` | Component name for resource tagging | `BaseInfra` | `"CustomBaseInfra"` |
+| `tak-region` | Region identifier for tagging | `ap-southeast-2` | `"us-west-2"` |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1742,12 +1742,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1978,6 +1980,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/constructs": {
@@ -3491,6 +3494,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -3864,6 +3868,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/scripts/deploy/deployAllLayers
+++ b/scripts/deploy/deployAllLayers
@@ -201,7 +201,7 @@ else
     cd base-infra
     npm install
     export CDK_DEFAULT_REGION="$REGION"
-    npm run cdk deploy -- --context envType="$ENV_TYPE" --context stackName="$STACK_NAME" --context r53ZoneName="$R53_ZONE_NAME" --context 'tak-defaults={"project":"'"$PROJECT"'","component":"BaseInfra","region":"'"$REGION"'"}' --require-approval never $NO_ROLLBACK
+    npm run cdk deploy -- --context envType="$ENV_TYPE" --context stackName="$STACK_NAME" --context r53ZoneName="$R53_ZONE_NAME" --context tak-project="$PROJECT" --context tak-component="BaseInfra" --context tak-region="$REGION" --require-approval never $NO_ROLLBACK
     cd ..
     
     # Upload configuration files to S3
@@ -224,7 +224,7 @@ else
     cd auth-infra
     npm install
     export CDK_DEFAULT_REGION="$REGION"
-    npm run cdk deploy -- --context envType="$ENV_TYPE" --context stackName="$STACK_NAME" --context adminUserEmail="$ADMIN_USER_EMAIL" --context branding="$BRANDING" --context 'tak-defaults={"project":"'"$PROJECT"'","component":"AuthInfra","region":"'"$REGION"'"}' --require-approval never $NO_ROLLBACK
+    npm run cdk deploy -- --context envType="$ENV_TYPE" --context stackName="$STACK_NAME" --context adminUserEmail="$ADMIN_USER_EMAIL" --context branding="$BRANDING" --context tak-project="$PROJECT" --context tak-component="AuthInfra" --context tak-region="$REGION" --require-approval never $NO_ROLLBACK
     cd ..
     
     # Deploy TakInfra
@@ -234,13 +234,31 @@ else
     cp "$INITIAL_DIR/takserver-docker-$REQUIRED_VERSION.zip" .
     npm install
     export CDK_DEFAULT_REGION="$REGION"
-    npm run cdk deploy -- --context envType="$ENV_TYPE" --context stackName="$STACK_NAME" --context branding="$BRANDING" --context 'tak-defaults={"project":"'"$PROJECT"'","component":"TakInfra","region":"'"$REGION"'"}' --require-approval never $NO_ROLLBACK
+    npm run cdk deploy -- --context envType="$ENV_TYPE" --context stackName="$STACK_NAME" --context branding="$BRANDING" --context tak-project="$PROJECT" --context tak-component="TakInfra" --context tak-region="$REGION" --require-approval never $NO_ROLLBACK
     cd ..
     
     # Calculate and display deployment duration
     END_TIME=$(date +%s)
     DURATION=$((END_TIME - START_TIME))
     MINUTES=$((DURATION / 60))
+    SECONDS=$((DURATION % 60))
+    
+    echo ""
+    echo "🎉 TAK infrastructure deployed successfully!"
+    echo "⏱️  Total deployment time: ${MINUTES}m ${SECONDS}s"
+    echo ""
+    echo "📋 Deployment Summary:"
+    echo "   • Environment: $ENV_TYPE"
+    echo "   • Stack Name: $STACK_NAME"
+    echo "   • Region: $REGION"
+    echo "   • Domain: $R53_ZONE_NAME"
+    echo "   • Project: $PROJECT"
+    echo ""
+    echo "🔗 Next Steps:"
+    echo "   • Check CloudFormation stacks in AWS Console"
+    echo "   • Verify DNS records in Route53"
+    echo "   • Test application endpoints"
+fiDURATION / 60))
     SECONDS=$((DURATION % 60))
     echo ""
     echo "========================================"


### PR DESCRIPTION
# Fix: Context Parameter Parsing Issue

## Problem
Project name "TAK on AWS" was being truncated to "TAK" in CloudFormation tags due to CDK not parsing JSON strings passed via `--context` flag.

## Solution
- Replace JSON object context parameters with individual parameters
- Use `tak-project`, `tak-component`, `tak-region` instead of `tak-defaults` JSON
- Maintain backward compatibility with existing `tak-defaults` object

## Changes
- **bin/cdk.ts**: Updated context retrieval to use individual parameters with fallback
- **scripts/deploy/deployAllLayers**: Updated all layer deployments to use individual parameters
- **docs/PARAMETERS.md**: Added documentation for new parameter usage
- **docs/CONTEXT_PARAMETER_FIX.md**: Implementation guide for other stacks

## Testing
Project name now correctly appears as "TAK on AWS" in CloudFormation stack tags instead of falling back to "TAK".
