### PR TITLE
Add globally unique S3 bucket naming

### DIFF
--- a/lib/base-infra-stack.ts
+++ b/lib/base-infra-stack.ts
@@ -51,7 +51,7 @@ export class BaseInfraStack extends cdk.Stack {
     const { ecsCluster } = createEcsResources(this, this.stackName, vpc);
     const { ecrRepo } = createEcrResources(this, this.stackName, imageRetentionCount, scanOnPush, removalPolicy);
     const { kmsKey, kmsAlias } = createKmsResources(this, this.stackName, enableKeyRotation, removalPolicy);
-    const { configBucket, appImagesBucket } = createS3Resources(this, this.stackName, cdk.Stack.of(this).region, kmsKey, enableVersioning, removalPolicy);
+    const { configBucket, envConfigBucket, appImagesBucket } = createS3Resources(this, this.stackName, cdk.Stack.of(this).region, kmsKey, enableVersioning, removalPolicy);
 
     // Endpoint Security Group (for interface endpoints)
     let endpointSg: ec2.SecurityGroup | undefined = undefined;
@@ -95,6 +95,7 @@ export class BaseInfraStack extends cdk.Stack {
       kmsKey,
       kmsAlias,
       configBucket,
+      envConfigBucket,
       appImagesBucket,
       vpcEndpoints,
       certificate,

--- a/lib/outputs.ts
+++ b/lib/outputs.ts
@@ -18,6 +18,7 @@ export interface OutputParams {
   kmsKey: kms.Key;
   kmsAlias: kms.Alias;
   configBucket: s3.Bucket;
+  envConfigBucket: s3.Bucket;
   appImagesBucket: s3.Bucket;
   vpcEndpoints?: Record<string, ec2.GatewayVpcEndpoint | ec2.InterfaceVpcEndpoint>;
   certificate?: acm.Certificate;
@@ -52,6 +53,27 @@ export function registerOutputs(params: OutputParams): void {
       description,
       exportName: `${stackName}-${key}`,
     });
+  });
+
+  // Legacy ConfigBucket export (for migration)
+  new cdk.CfnOutput(stack, 'ConfigBucketOutput', {
+    value: params.configBucket.bucketName,
+    description: 'Legacy configuration bucket (deprecated)',
+    exportName: `${stackName}-ConfigBucket`,
+  });
+
+  // New EnvConfigBucket export
+  new cdk.CfnOutput(stack, 'EnvConfigBucketOutput', {
+    value: params.envConfigBucket.bucketName,
+    description: 'Environment configuration bucket with globally unique naming',
+    exportName: `${stackName}-EnvConfigBucket`,
+  });
+
+  // AppImagesBucket export (updated with new naming)
+  new cdk.CfnOutput(stack, 'AppImagesBucketOutput', {
+    value: params.appImagesBucket.bucketName,
+    description: 'Application images bucket with globally unique naming',
+    exportName: `${stackName}-AppImagesBucket`,
   });
 
   // Conditional outputs

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -18,7 +18,7 @@ describe('AWS Resources', () => {
     template.resourceCountIs('AWS::ECR::Repository', 1);
     template.resourceCountIs('AWS::KMS::Key', 1);
     template.resourceCountIs('AWS::KMS::Alias', 1);
-    template.resourceCountIs('AWS::S3::Bucket', 2);
+    template.resourceCountIs('AWS::S3::Bucket', 3);
     template.resourceCountIs('AWS::CertificateManager::Certificate', 1);
     template.hasResourceProperties('AWS::S3::Bucket', {
       OwnershipControls: {


### PR DESCRIPTION
# Add globally unique S3 bucket naming

## Changes
- **New bucket**: `EnvConfigBucket` with account ID suffix for global uniqueness
- **Updated bucket**: `AppImagesBucket` now includes account ID
- **Legacy support**: Keep existing `ConfigBucket` for migration
- **New exports**: Added `EnvConfigBucket` and updated `AppImagesBucket` exports

## Bucket Names
- **Legacy**: `tak-demo-baseinfra-us-west-2-env-config` (unchanged)
- **New**: `tak-demo-baseinfra-us-west-2-123456789012-env-config`
- **Updated**: `tak-demo-baseinfra-us-west-2-123456789012-app-images`

## Migration Path
1. Deploy this change (creates new buckets alongside old)
2. Update dependent stacks to use new `EnvConfigBucket` export
3. Update build scripts for new `AppImagesBucket` name
4. Remove legacy `ConfigBucket` after migration

## Exports
- `TAK-Demo-BaseInfra-ConfigBucket` (legacy - unchanged)
- `TAK-Demo-BaseInfra-EnvConfigBucket` (new)
- `TAK-Demo-BaseInfra-AppImagesBucket` (updated)
