### PR TITLE
Fix S3 bucket name length limit violation

### DIFF
--- a/lib/constructs/services.ts
+++ b/lib/constructs/services.ts
@@ -71,7 +71,7 @@ export function createS3Resources(scope: Construct, stackName: string, region: s
 
   // New config bucket with globally unique naming
   const envConfigBucket = new s3.Bucket(scope, 'EnvConfigBucket', {
-    bucketName: `tak-${stackName.toLowerCase()}-baseinfra-${region}-${cdk.Aws.ACCOUNT_ID}-env-config`,
+    bucketName: `tak-${stackName.toLowerCase()}-${region}-${cdk.Aws.ACCOUNT_ID}-config`,
     encryption: s3.BucketEncryption.KMS,
     encryptionKey: kmsKey,
     bucketKeyEnabled: true,
@@ -84,7 +84,7 @@ export function createS3Resources(scope: Construct, stackName: string, region: s
 
   // Updated app images bucket with globally unique naming
   const appImagesBucket = new s3.Bucket(scope, 'AppImagesBucket', {
-    bucketName: `tak-${stackName.toLowerCase()}-baseinfra-${region}-${cdk.Aws.ACCOUNT_ID}-app-images`,
+    bucketName: `tak-${stackName.toLowerCase()}-${region}-${cdk.Aws.ACCOUNT_ID}-artifacts`,
     encryption: s3.BucketEncryption.KMS,
     encryptionKey: kmsKey,
     bucketKeyEnabled: true,


### PR DESCRIPTION
# Fix S3 bucket name length limit violation

## Problem
S3 bucket names exceeded 63-character limit causing deployment failures:
- Previous: `tak-demo-baseinfra-us-west-2-123456789012-env-config` (54+ chars)

## Solution
- **Shortened naming**: Removed "baseinfra" and shortened suffixes
- **New names**: `tak-demo-us-west-2-123456789012-config` (~37 chars)
- **Artifacts bucket**: Changed from "app-images" to "artifacts" for clarity
- **Removed legacy**: No longer need gradual migration approach

## Final Bucket Names
- `tak-{stack}-{region}-{account}-config`
- `tak-{stack}-{region}-{account}-artifacts`

## Changes
- Shortened bucket naming pattern in `services.ts`
- Updated test expectations (2 buckets instead of 3)
- Updated exports to match new naming
