### PR TITLE
Fix duplicate S3 bucket exports

### DIFF
--- a/lib/outputs.ts
+++ b/lib/outputs.ts
@@ -43,8 +43,7 @@ export function registerOutputs(params: OutputParams): void {
     { key: 'EcrRepoArn', value: params.ecrRepo.repositoryArn, description: 'ECR Repository ARN' },
     { key: 'KmsKeyArn', value: params.kmsKey.keyArn, description: 'KMS Key ARN' },
     { key: 'KmsAlias', value: params.kmsAlias.aliasName, description: 'KMS Key Alias' },
-    { key: 'S3BucketArn', value: params.configBucket.bucketArn, description: 'S3 Configuration Bucket ARN' },
-    { key: 'S3TAKImagesArn', value: params.appImagesBucket.bucketArn, description: 'S3 TAK Images Bucket ARN' },
+
   ];
 
   outputs.forEach(({ key, value, description }) => {

--- a/test/outputs.test.ts
+++ b/test/outputs.test.ts
@@ -17,7 +17,8 @@ describe('Stack Outputs', () => {
     [
       'VpcIdOutput', 'VpcCidrIpv4Output',
       'SubnetPublicAOutput', 'SubnetPublicBOutput', 'SubnetPrivateAOutput', 'SubnetPrivateBOutput',
-      'EcsClusterArnOutput', 'EcrRepoArnOutput', 'KmsKeyArnOutput', 'KmsAliasOutput', 'S3BucketArnOutput',
+      'EcsClusterArnOutput', 'EcrRepoArnOutput', 'KmsKeyArnOutput', 'KmsAliasOutput',
+      'ConfigBucketOutput', 'EnvConfigBucketOutput', 'AppImagesBucketOutput',
       'CertificateArnOutput', 'HostedZoneIdOutput', 'HostedZoneNameOutput'
     ].forEach(name => {
       expect(outputs[name]).toBeDefined();


### PR DESCRIPTION
# Fix duplicate S3 bucket exports

## Problem
Only 2 of 3 S3 bucket exports were visible due to duplicate/conflicting exports in the outputs configuration.

## Solution
- **Removed duplicates**: Generic `S3BucketArn` and `S3TAKImagesArn` exports
- **Keep specific exports**: `ConfigBucket`, `EnvConfigBucket`, `AppImagesBucket`
- **Updated tests**: Check for correct export names

## Result
All 3 bucket exports now visible:
- `TAK-Demo-BaseInfra-ConfigBucket` (legacy)
- `TAK-Demo-BaseInfra-EnvConfigBucket` (new globally unique)
- `TAK-Demo-BaseInfra-AppImagesBucket` (updated globally unique)

## Changes
- Fixed `outputs.ts` duplicate exports
- Updated `outputs.test.ts` expectations
- All tests passing
