### PR TITLE
Restore S3BucketArn export for gradual migration

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -9,6 +9,10 @@ on:
       - '.gitignore'
   workflow_dispatch:
 
+concurrency:
+  group: demo-deploy
+  cancel-in-progress: false
+
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -11,6 +11,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
 permissions:
   id-token: write
   contents: read

--- a/lib/outputs.ts
+++ b/lib/outputs.ts
@@ -43,6 +43,7 @@ export function registerOutputs(params: OutputParams): void {
     { key: 'EcrRepoArn', value: params.ecrRepo.repositoryArn, description: 'ECR Repository ARN' },
     { key: 'KmsKeyArn', value: params.kmsKey.keyArn, description: 'KMS Key ARN' },
     { key: 'KmsAlias', value: params.kmsAlias.aliasName, description: 'KMS Key Alias' },
+    { key: 'S3BucketArn', value: params.configBucket.bucketArn, description: 'S3 Configuration Bucket ARN' },
 
   ];
 


### PR DESCRIPTION
# Restore S3BucketArn export for gradual migration

## Problem
Removed `S3BucketArn` export but 3 dependent stacks still importing it:
- `TAK-Demo-AuthInfra`
- `TAK-Demo-CloudTAK` 
- `TAK-Demo-TakInfra`

## Solution
- **Restored**: `S3BucketArn` export pointing to legacy `configBucket`
- **Added**: Workflow concurrency controls for safe deployments
- **Maintained**: All bucket exports for gradual migration

## Current Exports
**Legacy (keep during migration):**
- `TAK-Demo-BaseInfra-S3BucketArn`
- `TAK-Demo-BaseInfra-ConfigBucket`

**New (globally unique):**
- `TAK-Demo-BaseInfra-EnvConfigBucket`
- `TAK-Demo-BaseInfra-AppImagesBucket`

## Changes
- Restored `S3BucketArn` in `outputs.ts`
- Added concurrency controls to workflows
