### PR TITLE
Fix demo workflow stack name validation

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -50,7 +50,7 @@ jobs:
           if [[ "${{ github.event.head_commit.message }}" == *"[force-deploy]"* ]]; then
             echo "🚨 Force deploy detected - skipping change set validation"
           else
-            ./scripts/github/validate-changeset.sh ${{ vars.STACK_NAME }}
+            ./scripts/github/validate-changeset.sh TAK-${{ vars.STACK_NAME }}-BaseInfra
           fi
 
       - name: Deploy Demo with Prod Profile


### PR DESCRIPTION
# Fix demo workflow stack name validation

## Problem
Demo workflow validation failing with "Stack [Demo] does not exist" because:
- Script called with `Demo` (short name)
- Actual CloudFormation stack name is `TAK-Demo-BaseInfra` (full name)

## Solution
- **Fixed**: Use `TAK-${{ vars.STACK_NAME }}-BaseInfra` in validation call
- **Production**: Already correct with hardcoded `TAK-Prod-BaseInfra`

## Changes
- Updated `demo-deploy.yml` validation script call
- No changes needed for `production-deploy.yml`
