### PR TITLE
Add ALB access logs bucket with proper permissions

### DIFF
--- a/lib/constructs/services.ts
+++ b/lib/constructs/services.ts
@@ -108,5 +108,35 @@ export function createS3Resources(scope: Construct, stackName: string, region: s
     objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_ENFORCED,
   });
 
+  // Grant ALB service account permission to write access logs
+  const elbServiceAccountMap: { [key: string]: string } = {
+    'us-east-1': '127311923021', 'us-east-2': '033677994240', 'us-west-1': '027434742980', 'us-west-2': '797873946194',
+    'ca-central-1': '985666609251', 'eu-central-1': '054676820928', 'eu-west-1': '156460612806', 'eu-west-2': '652711504416',
+    'eu-west-3': '009996457667', 'eu-north-1': '897822967062', 'eu-south-1': '635631232127', 'ap-east-1': '754344448648',
+    'ap-northeast-1': '582318560864', 'ap-northeast-2': '600734575887', 'ap-northeast-3': '383597477331', 'ap-southeast-1': '114774131450',
+    'ap-southeast-2': '783225319266', 'ap-southeast-3': '589379963580', 'ap-south-1': '718504428378', 'me-south-1': '076674570225',
+    'sa-east-1': '507241528517', 'af-south-1': '098369216593', 'us-gov-west-1': '048591011584', 'us-gov-east-1': '190560391635'
+  };
+  
+  const elbPrincipal = elbServiceAccountMap[region] 
+    ? new cdk.aws_iam.AccountPrincipal(elbServiceAccountMap[region])
+    : new cdk.aws_iam.ServicePrincipal('elasticloadbalancing.amazonaws.com');
+  
+  albLogsBucket.addToResourcePolicy(new PolicyStatement({
+    effect: Effect.ALLOW,
+    principals: [elbPrincipal],
+    actions: ['s3:PutObject'],
+    resources: [`${albLogsBucket.bucketArn}/*`]
+  }));
+  
+  albLogsBucket.addToResourcePolicy(new PolicyStatement({
+    effect: Effect.ALLOW,
+    principals: [elbPrincipal],
+    actions: ['s3:GetBucketAcl'],
+    resources: [albLogsBucket.bucketArn]
+  }));
+
+
+
   return { configBucket, envConfigBucket, appImagesBucket, albLogsBucket };
 }


### PR DESCRIPTION
# Add ALB access logs bucket with proper permissions

## Changes
- **Added**: ALB logs bucket `tak-{stack}-{region}-{account}-logs`
- **Permissions**: ALB service account access for all AWS regions
- **Fallback**: Service principal if region not in mapping
- **Fixed**: Duplicate permission code removed
- **Updated**: Test expects 4 buckets

## ALB Permissions
- `s3:PutObject` on `bucket/*` for log writing
- `s3:GetBucketAcl` on bucket for access verification
- Region-specific service accounts with fallback

## S3 Buckets (4 total)
1. `configBucket` - Legacy (migration)
2. `envConfigBucket` - Config with global naming  
3. `appImagesBucket` - Artifacts with global naming
4. `albLogsBucket` - ALB logs with global naming + permissions

## Exports
- `TAK-Demo-BaseInfra-S3AlbLogsArn` (ARN)
- `TAK-Demo-BaseInfra-AlbLogsBucket` (name)
