### PR TITLE
Fix ALB Logs Bucket Access Denied Error

### DIFF
--- a/lib/constructs/services.ts
+++ b/lib/constructs/services.ts
@@ -136,7 +136,17 @@ export function createS3Resources(scope: Construct, stackName: string, region: s
     resources: [albLogsBucket.bucketArn]
   }));
 
-
+  // Allow cross-stack access for other TAK infrastructure layers
+  albLogsBucket.addToResourcePolicy(new PolicyStatement({
+    effect: Effect.ALLOW,
+    principals: [new AccountRootPrincipal()],
+    actions: [
+      's3:GetBucketLocation',
+      's3:GetBucketAcl',
+      's3:ListBucket'
+    ],
+    resources: [albLogsBucket.bucketArn]
+  }));
 
   return { configBucket, envConfigBucket, appImagesBucket, albLogsBucket };
 }


### PR DESCRIPTION
## Fix ALB Logs Bucket Access Denied Error

### Problem
Other stacks accessing the ALB logs bucket were getting "Access Denied" errors when trying to configure load balancers.

### Solution
Added bucket policy allowing cross-stack read access (`GetBucketLocation`, `GetBucketAcl`, `ListBucket`) while preserving ELB service account write permissions.

### Changes
- Added `AccountRootPrincipal` policy to ALB logs bucket
- Maintains security by limiting to same AWS account
- Preserves existing ELB service permissions

Fixes the CloudFormation error: `Access Denied for bucket: tak-tak-demo-baseinfra-ap-southeast-2-648332710556-logs`
