### PR TITLE
Add Configurable ALB Logs Retention

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -35,7 +35,8 @@
         "enableKeyRotation": false
       },
       "s3": {
-        "enableVersioning": false
+        "enableVersioning": false,
+        "albLogsRetentionDays": 30
       },
       "ecr": {
         "imageRetentionCount": 5,
@@ -60,7 +61,8 @@
         "enableKeyRotation": true
       },
       "s3": {
-        "enableVersioning": true
+        "enableVersioning": true,
+        "albLogsRetentionDays": 30
       },
       "ecr": {
         "imageRetentionCount": 20,

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -110,6 +110,7 @@ Use CDK's built-in `--context` flag with **flat parameter names** to override an
 | Parameter | Description | dev-test | prod |
 |-----------|-------------|----------|------|
 | `enableVersioning` | S3 bucket versioning | `false` | `true` |
+| `albLogsRetentionDays` | ALB access logs retention period | `30` | `30` |
 | `lifecycleRules` | S3 lifecycle management | `true` | `true` |
 
 ---
@@ -205,6 +206,9 @@ npm run deploy:prod -- --context createVpcEndpoints=false
 npm run deploy:prod -- \
   --context enableVersioning=false \
   --context enableKeyRotation=false
+
+# ALB logs retention (7 days for cost savings)
+npm run deploy:dev -- --context albLogsRetentionDays=7
 
 # Certificate settings
 npm run deploy:dev -- --context transparencyLoggingEnabled=false

--- a/lib/base-infra-stack.ts
+++ b/lib/base-infra-stack.ts
@@ -51,7 +51,7 @@ export class BaseInfraStack extends cdk.Stack {
     const { ecsCluster } = createEcsResources(this, this.stackName, vpc);
     const { ecrRepo } = createEcrResources(this, this.stackName, imageRetentionCount, scanOnPush, removalPolicy);
     const { kmsKey, kmsAlias } = createKmsResources(this, this.stackName, enableKeyRotation, removalPolicy);
-    const { configBucket, envConfigBucket, appImagesBucket, albLogsBucket } = createS3Resources(this, this.stackName, cdk.Stack.of(this).region, kmsKey, enableVersioning, removalPolicy);
+    const { configBucket, envConfigBucket, appImagesBucket, albLogsBucket } = createS3Resources(this, this.stackName, cdk.Stack.of(this).region, kmsKey, enableVersioning, removalPolicy, envConfig.s3.albLogsRetentionDays);
 
     // Endpoint Security Group (for interface endpoints)
     let endpointSg: ec2.SecurityGroup | undefined = undefined;

--- a/lib/stack-config.ts
+++ b/lib/stack-config.ts
@@ -26,6 +26,7 @@ export interface ContextEnvironmentConfig {
   };
   s3: {
     enableVersioning: boolean;
+    albLogsRetentionDays: number;
   };
   ecr: {
     imageRetentionCount: number;

--- a/test/acm.test.ts
+++ b/test/acm.test.ts
@@ -20,7 +20,7 @@ describe('ACM Certificate', () => {
           certificate: { transparencyLoggingEnabled: true },
           general: { removalPolicy: 'RETAIN' },
           kms: { enableKeyRotation: true },
-          s3: { enableVersioning: true },
+          s3: { enableVersioning: true, albLogsRetentionDays: 30 },
           ecr: { imageRetentionCount: 20, scanOnPush: true }
         },
         'tak-defaults': { project: 'TAK', component: 'BaseInfra', region: 'ap-southeast-2' }
@@ -66,7 +66,7 @@ describe('ACM Certificate', () => {
           certificate: { transparencyLoggingEnabled: true },
           general: { removalPolicy: 'RETAIN' },
           kms: { enableKeyRotation: true },
-          s3: { enableVersioning: true },
+          s3: { enableVersioning: true, albLogsRetentionDays: 30 },
           ecr: { imageRetentionCount: 20, scanOnPush: true }
         }
       });
@@ -83,7 +83,7 @@ describe('ACM Certificate', () => {
           certificate: { transparencyLoggingEnabled: true },
           general: { removalPolicy: 'RETAIN' },
           kms: { enableKeyRotation: true },
-          s3: { enableVersioning: true },
+          s3: { enableVersioning: true, albLogsRetentionDays: 30 },
           ecr: { imageRetentionCount: 20, scanOnPush: true }
         }
       });
@@ -119,7 +119,7 @@ describe('ACM Certificate', () => {
           certificate: { transparencyLoggingEnabled: true },
           general: { removalPolicy: 'RETAIN' },
           kms: { enableKeyRotation: true },
-          s3: { enableVersioning: true },
+          s3: { enableVersioning: true, albLogsRetentionDays: 30 },
           ecr: { imageRetentionCount: 20, scanOnPush: true }
         }
       });
@@ -142,7 +142,7 @@ describe('ACM Certificate', () => {
           certificate: { transparencyLoggingEnabled: true },
           general: { removalPolicy: 'RETAIN' },
           kms: { enableKeyRotation: true },
-          s3: { enableVersioning: true },
+          s3: { enableVersioning: true, albLogsRetentionDays: 30 },
           ecr: { imageRetentionCount: 20, scanOnPush: true }
         },
         'tak-defaults': { project: 'TAK', component: 'BaseInfra', region: 'ap-southeast-2' }
@@ -180,7 +180,7 @@ describe('ACM Certificate', () => {
           certificate: { transparencyLoggingEnabled: false },
           general: { removalPolicy: 'DESTROY' },
           kms: { enableKeyRotation: false },
-          s3: { enableVersioning: false },
+          s3: { enableVersioning: false, albLogsRetentionDays: 30 },
           ecr: { imageRetentionCount: 5, scanOnPush: false }
         },
         'tak-defaults': { project: 'TAK', component: 'BaseInfra', region: 'ap-southeast-2' }
@@ -223,7 +223,7 @@ describe('ACM Certificate', () => {
       certificate: { transparencyLoggingEnabled: true }, // Override dev-test default
       general: { removalPolicy: 'DESTROY' },
       kms: { enableKeyRotation: false },
-      s3: { enableVersioning: false },
+      s3: { enableVersioning: false, albLogsRetentionDays: 30 },
       ecr: { imageRetentionCount: 5, scanOnPush: false }
     };
     

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -25,7 +25,7 @@ describe('Integration Tests', () => {
       certificate: { transparencyLoggingEnabled: false },
       general: { removalPolicy: 'DESTROY' },
       kms: { enableKeyRotation: false },
-      s3: { enableVersioning: false },
+      s3: { enableVersioning: false, albLogsRetentionDays: 30 },
       ecr: { imageRetentionCount: 5, scanOnPush: false }
     };
     

--- a/test/parameters.test.ts
+++ b/test/parameters.test.ts
@@ -10,7 +10,7 @@ describe('Stack Configuration', () => {
       certificate: { transparencyLoggingEnabled: true },
       general: { removalPolicy: 'RETAIN' },
       kms: { enableKeyRotation: true },
-      s3: { enableVersioning: true },
+      s3: { enableVersioning: true, albLogsRetentionDays: 30 },
       ecr: { imageRetentionCount: 20, scanOnPush: true }
     };
 
@@ -22,7 +22,7 @@ describe('Stack Configuration', () => {
       certificate: { transparencyLoggingEnabled: false },
       general: { removalPolicy: 'DESTROY' },
       kms: { enableKeyRotation: false },
-      s3: { enableVersioning: false },
+      s3: { enableVersioning: false, albLogsRetentionDays: 30 },
       ecr: { imageRetentionCount: 5, scanOnPush: false }
     };
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -13,7 +13,7 @@ const createTestConfig = (overrides: Partial<ContextEnvironmentConfig> = {}): Co
     removalPolicy: 'DESTROY'
   },
   kms: { enableKeyRotation: true },
-  s3: { enableVersioning: true },
+  s3: { enableVersioning: true, albLogsRetentionDays: 30 },
   ecr: { imageRetentionCount: 5, scanOnPush: true },
   ...overrides
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -54,7 +54,8 @@ export function createTestApp(): cdk.App {
           enableKeyRotation: false
         },
         s3: {
-          enableVersioning: false
+          enableVersioning: false,
+          albLogsRetentionDays: 30
         },
         ecr: {
           imageRetentionCount: 5,
@@ -79,7 +80,8 @@ export function createTestApp(): cdk.App {
           enableKeyRotation: true
         },
         s3: {
-          enableVersioning: true
+          enableVersioning: true,
+          albLogsRetentionDays: 30
         },
         ecr: {
           imageRetentionCount: 20,


### PR DESCRIPTION
## Add Configurable ALB Logs Retention

### Problem
ALB access logs were hardcoded to 30-day retention with no configuration option for cost optimization or compliance requirements.

### Solution
- Added `albLogsRetentionDays` parameter to S3 configuration
- Configurable via `cdk.json` and `--context` overrides
- Fixed ALB logs bucket permissions (SSE-S3 encryption, proper service account access)
- Added lifecycle policy for automatic log cleanup

### Changes
- **Configuration**: Added `s3.albLogsRetentionDays` parameter (default: 30 days)
- **Infrastructure**: Fixed bucket encryption and service account permissions
- **Tests**: Updated all test configurations to include new parameter
- **Documentation**: Added usage examples and parameter reference

### Usage
```bash
# Default 30-day retention
npm run deploy:dev

# Custom retention for cost savings
npm run deploy:dev -- --context albLogsRetentionDays=7

# Extended retention for compliance
npm run deploy:prod -- --context albLogsRetentionDays=90
