### PR TITLE
## Fix S3 Auto-Delete Permission Error

### DIFF
--- a/lib/constructs/services.ts
+++ b/lib/constructs/services.ts
@@ -142,6 +142,7 @@ export function createS3Resources(scope: Construct, stackName: string, region: s
     actions: [
       's3:GetBucketLocation',
       's3:GetBucketAcl',
+      's3:GetBucketTagging',
       's3:ListBucket'
     ],
     resources: [albLogsBucket.bucketArn]


### PR DESCRIPTION

### Solution
Added `s3:GetBucketTagging` permission to ALB logs bucket policy for account root principal.

### Changes
- Added `s3:GetBucketTagging` to existing bucket policy permissions
- Required by CDK's auto-delete custom resource when `autoDeleteObjects: true`

### Testing
- Resolves deployment failure for stacks with `removalPolicy !== 'RETAIN'`
