### PR TITLE
Fix NLB Access Denied Error for S3 Logs Bucket

### DIFF
--- a/lib/constructs/services.ts
+++ b/lib/constructs/services.ts
@@ -135,6 +135,14 @@ export function createS3Resources(scope: Construct, stackName: string, region: s
     resources: [albLogsBucket.bucketArn]
   }));
 
+  // Grant NLB service account permission to write access logs
+  albLogsBucket.addToResourcePolicy(new PolicyStatement({
+    effect: Effect.ALLOW,
+    principals: [new cdk.aws_iam.ServicePrincipal('elasticloadbalancing.amazonaws.com')],
+    actions: ['s3:PutObject', 's3:GetBucketAcl'],
+    resources: [albLogsBucket.bucketArn, `${albLogsBucket.bucketArn}/*`]
+  }));
+
   // Allow cross-stack access for other TAK infrastructure layers
   albLogsBucket.addToResourcePolicy(new PolicyStatement({
     effect: Effect.ALLOW,


### PR DESCRIPTION
## Fix NLB Access Denied Error for S3 Logs Bucket

### Problem
NLB deployment failing with Access Denied error when attempting to write access logs to S3 bucket.

### Solution
Added service principal permissions for `elasticloadbalancing.amazonaws.com` to allow:
- `s3:PutObject` - Write access logs
- `s3:GetBucketAcl` - Read bucket ACL (required for log delivery)

### Changes
- Updated `lib/constructs/services.ts` to include NLB service account policy

Fixes deployment error: `Access Denied for bucket: tak-demo-baseinfra-ap-southeast-2-648332710556-logs`
