### PR TITLE
Fix S3 Auto-Delete Objects AccessDenied Error

### DIFF
--- a/lib/constructs/services.ts
+++ b/lib/constructs/services.ts
@@ -143,9 +143,12 @@ export function createS3Resources(scope: Construct, stackName: string, region: s
       's3:GetBucketLocation',
       's3:GetBucketAcl',
       's3:GetBucketTagging',
-      's3:ListBucket'
+      's3:ListBucket',
+      's3:DeleteObject',
+      's3:ListBucketVersions',
+      's3:DeleteObjectVersion'
     ],
-    resources: [albLogsBucket.bucketArn]
+    resources: [albLogsBucket.bucketArn, `${albLogsBucket.bucketArn}/*`]
   }));
 
   return { configBucket, envConfigBucket, appImagesBucket, albLogsBucket };


### PR DESCRIPTION
## Fix S3 Auto-Delete Objects AccessDenied Error

### Problem
CustomS3AutoDeleteObjects resource failing with AccessDenied when attempting to clean up S3 bucket objects during stack deletion.

### Solution
Added missing S3 permissions to cross-stack access policy:
- `s3:DeleteObject` - Delete individual objects
- `s3:ListBucketVersions` - List object versions
- `s3:DeleteObjectVersion` - Delete specific versions
- Extended resource scope to include `/*` for object-level operations

### Changes
- Updated `lib/constructs/services.ts` S3 bucket policy

Fixes error: `User is not authorized to perform: s3:GetBucketTagging`
