### PR TITLE
Fix ELB S3 Log Delivery Access Denied Error

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -36,7 +36,7 @@
       },
       "s3": {
         "enableVersioning": false,
-        "albLogsRetentionDays": 30
+        "elbLogsRetentionDays": 30
       },
       "ecr": {
         "imageRetentionCount": 5,
@@ -62,7 +62,7 @@
       },
       "s3": {
         "enableVersioning": true,
-        "albLogsRetentionDays": 30
+        "elbLogsRetentionDays": 30
       },
       "ecr": {
         "imageRetentionCount": 20,

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -110,7 +110,7 @@ Use CDK's built-in `--context` flag with **flat parameter names** to override an
 | Parameter | Description | dev-test | prod |
 |-----------|-------------|----------|------|
 | `enableVersioning` | S3 bucket versioning | `false` | `true` |
-| `albLogsRetentionDays` | ALB access logs retention period | `30` | `30` |
+| `elbLogsRetentionDays` | ELB access logs retention period | `30` | `30` |
 | `lifecycleRules` | S3 lifecycle management | `true` | `true` |
 
 ---
@@ -207,8 +207,8 @@ npm run deploy:prod -- \
   --context enableVersioning=false \
   --context enableKeyRotation=false
 
-# ALB logs retention (7 days for cost savings)
-npm run deploy:dev -- --context albLogsRetentionDays=7
+# ELB logs retention (7 days for cost savings)
+npm run deploy:dev -- --context elbLogsRetentionDays=7
 
 # Certificate settings
 npm run deploy:dev -- --context transparencyLoggingEnabled=false

--- a/lib/base-infra-stack.ts
+++ b/lib/base-infra-stack.ts
@@ -51,7 +51,7 @@ export class BaseInfraStack extends cdk.Stack {
     const { ecsCluster } = createEcsResources(this, this.stackName, vpc);
     const { ecrRepo } = createEcrResources(this, this.stackName, imageRetentionCount, scanOnPush, removalPolicy);
     const { kmsKey, kmsAlias } = createKmsResources(this, this.stackName, enableKeyRotation, removalPolicy);
-    const { configBucket, envConfigBucket, appImagesBucket, albLogsBucket } = createS3Resources(this, this.stackName, cdk.Stack.of(this).region, kmsKey, enableVersioning, removalPolicy, envConfig.s3.albLogsRetentionDays);
+    const { configBucket, envConfigBucket, appImagesBucket, elbLogsBucket } = createS3Resources(this, this.stackName, cdk.Stack.of(this).region, kmsKey, enableVersioning, removalPolicy, envConfig.s3.elbLogsRetentionDays);
 
     // Endpoint Security Group (for interface endpoints)
     let endpointSg: ec2.SecurityGroup | undefined = undefined;
@@ -97,7 +97,7 @@ export class BaseInfraStack extends cdk.Stack {
       configBucket,
       envConfigBucket,
       appImagesBucket,
-      albLogsBucket,
+      elbLogsBucket,
       vpcEndpoints,
       certificate,
       hostedZone,

--- a/lib/outputs.ts
+++ b/lib/outputs.ts
@@ -20,7 +20,7 @@ export interface OutputParams {
   configBucket: s3.Bucket;
   envConfigBucket: s3.Bucket;
   appImagesBucket: s3.Bucket;
-  albLogsBucket: s3.Bucket;
+  elbLogsBucket: s3.Bucket;
   vpcEndpoints?: Record<string, ec2.GatewayVpcEndpoint | ec2.InterfaceVpcEndpoint>;
   certificate?: acm.Certificate;
   hostedZone?: route53.IHostedZone;
@@ -47,7 +47,7 @@ export function registerOutputs(params: OutputParams): void {
     { key: 'S3BucketArn', value: params.configBucket.bucketArn, description: 'S3 Configuration Bucket ARN' },
     { key: 'S3TAKImagesArn', value: params.appImagesBucket.bucketArn, description: 'S3 TAK Images Bucket ARN' },
     { key: 'S3EnvConfigArn', value: params.envConfigBucket.bucketArn, description: 'S3 Environment Config Bucket ARN' },
-    { key: 'S3AlbLogsArn', value: params.albLogsBucket.bucketArn, description: 'S3 ALB Access Logs Bucket ARN' },
+    { key: 'S3ElbLogsArn', value: params.elbLogsBucket.bucketArn, description: 'S3 ELB Access Logs Bucket ARN' },
 
   ];
 
@@ -80,11 +80,11 @@ export function registerOutputs(params: OutputParams): void {
     exportName: `${stackName}-AppImagesBucket`,
   });
 
-  // AlbLogsBucket export
-  new cdk.CfnOutput(stack, 'AlbLogsBucketOutput', {
-    value: params.albLogsBucket.bucketName,
-    description: 'ALB access logs bucket with globally unique naming',
-    exportName: `${stackName}-AlbLogsBucket`,
+  // ElbLogsBucket export
+  new cdk.CfnOutput(stack, 'ElbLogsBucketOutput', {
+    value: params.elbLogsBucket.bucketName,
+    description: 'ELB access logs bucket with globally unique naming (ALB and NLB)',
+    exportName: `${stackName}-ElbLogsBucket`,
   });
 
   // Conditional outputs

--- a/lib/stack-config.ts
+++ b/lib/stack-config.ts
@@ -26,7 +26,7 @@ export interface ContextEnvironmentConfig {
   };
   s3: {
     enableVersioning: boolean;
-    albLogsRetentionDays: number;
+    elbLogsRetentionDays: number;
   };
   ecr: {
     imageRetentionCount: number;

--- a/test/acm.test.ts
+++ b/test/acm.test.ts
@@ -20,7 +20,7 @@ describe('ACM Certificate', () => {
           certificate: { transparencyLoggingEnabled: true },
           general: { removalPolicy: 'RETAIN' },
           kms: { enableKeyRotation: true },
-          s3: { enableVersioning: true, albLogsRetentionDays: 30 },
+          s3: { enableVersioning: true, elbLogsRetentionDays: 30 },
           ecr: { imageRetentionCount: 20, scanOnPush: true }
         },
         'tak-defaults': { project: 'TAK', component: 'BaseInfra', region: 'ap-southeast-2' }
@@ -66,7 +66,7 @@ describe('ACM Certificate', () => {
           certificate: { transparencyLoggingEnabled: true },
           general: { removalPolicy: 'RETAIN' },
           kms: { enableKeyRotation: true },
-          s3: { enableVersioning: true, albLogsRetentionDays: 30 },
+          s3: { enableVersioning: true, elbLogsRetentionDays: 30 },
           ecr: { imageRetentionCount: 20, scanOnPush: true }
         }
       });
@@ -83,7 +83,7 @@ describe('ACM Certificate', () => {
           certificate: { transparencyLoggingEnabled: true },
           general: { removalPolicy: 'RETAIN' },
           kms: { enableKeyRotation: true },
-          s3: { enableVersioning: true, albLogsRetentionDays: 30 },
+          s3: { enableVersioning: true, elbLogsRetentionDays: 30 },
           ecr: { imageRetentionCount: 20, scanOnPush: true }
         }
       });
@@ -119,7 +119,7 @@ describe('ACM Certificate', () => {
           certificate: { transparencyLoggingEnabled: true },
           general: { removalPolicy: 'RETAIN' },
           kms: { enableKeyRotation: true },
-          s3: { enableVersioning: true, albLogsRetentionDays: 30 },
+          s3: { enableVersioning: true, elbLogsRetentionDays: 30 },
           ecr: { imageRetentionCount: 20, scanOnPush: true }
         }
       });
@@ -142,7 +142,7 @@ describe('ACM Certificate', () => {
           certificate: { transparencyLoggingEnabled: true },
           general: { removalPolicy: 'RETAIN' },
           kms: { enableKeyRotation: true },
-          s3: { enableVersioning: true, albLogsRetentionDays: 30 },
+          s3: { enableVersioning: true, elbLogsRetentionDays: 30 },
           ecr: { imageRetentionCount: 20, scanOnPush: true }
         },
         'tak-defaults': { project: 'TAK', component: 'BaseInfra', region: 'ap-southeast-2' }
@@ -180,7 +180,7 @@ describe('ACM Certificate', () => {
           certificate: { transparencyLoggingEnabled: false },
           general: { removalPolicy: 'DESTROY' },
           kms: { enableKeyRotation: false },
-          s3: { enableVersioning: false, albLogsRetentionDays: 30 },
+          s3: { enableVersioning: false, elbLogsRetentionDays: 30 },
           ecr: { imageRetentionCount: 5, scanOnPush: false }
         },
         'tak-defaults': { project: 'TAK', component: 'BaseInfra', region: 'ap-southeast-2' }
@@ -223,7 +223,7 @@ describe('ACM Certificate', () => {
       certificate: { transparencyLoggingEnabled: true }, // Override dev-test default
       general: { removalPolicy: 'DESTROY' },
       kms: { enableKeyRotation: false },
-      s3: { enableVersioning: false, albLogsRetentionDays: 30 },
+      s3: { enableVersioning: false, elbLogsRetentionDays: 30 },
       ecr: { imageRetentionCount: 5, scanOnPush: false }
     };
     

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -25,7 +25,7 @@ describe('Integration Tests', () => {
       certificate: { transparencyLoggingEnabled: false },
       general: { removalPolicy: 'DESTROY' },
       kms: { enableKeyRotation: false },
-      s3: { enableVersioning: false, albLogsRetentionDays: 30 },
+      s3: { enableVersioning: false, elbLogsRetentionDays: 30 },
       ecr: { imageRetentionCount: 5, scanOnPush: false }
     };
     

--- a/test/parameters.test.ts
+++ b/test/parameters.test.ts
@@ -10,7 +10,7 @@ describe('Stack Configuration', () => {
       certificate: { transparencyLoggingEnabled: true },
       general: { removalPolicy: 'RETAIN' },
       kms: { enableKeyRotation: true },
-      s3: { enableVersioning: true, albLogsRetentionDays: 30 },
+      s3: { enableVersioning: true, elbLogsRetentionDays: 30 },
       ecr: { imageRetentionCount: 20, scanOnPush: true }
     };
 
@@ -22,7 +22,7 @@ describe('Stack Configuration', () => {
       certificate: { transparencyLoggingEnabled: false },
       general: { removalPolicy: 'DESTROY' },
       kms: { enableKeyRotation: false },
-      s3: { enableVersioning: false, albLogsRetentionDays: 30 },
+      s3: { enableVersioning: false, elbLogsRetentionDays: 30 },
       ecr: { imageRetentionCount: 5, scanOnPush: false }
     };
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -13,7 +13,7 @@ const createTestConfig = (overrides: Partial<ContextEnvironmentConfig> = {}): Co
     removalPolicy: 'DESTROY'
   },
   kms: { enableKeyRotation: true },
-  s3: { enableVersioning: true, albLogsRetentionDays: 30 },
+  s3: { enableVersioning: true, elbLogsRetentionDays: 30 },
   ecr: { imageRetentionCount: 5, scanOnPush: true },
   ...overrides
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -55,7 +55,7 @@ export function createTestApp(): cdk.App {
         },
         s3: {
           enableVersioning: false,
-          albLogsRetentionDays: 30
+          elbLogsRetentionDays: 30
         },
         ecr: {
           imageRetentionCount: 5,
@@ -81,7 +81,7 @@ export function createTestApp(): cdk.App {
         },
         s3: {
           enableVersioning: true,
-          albLogsRetentionDays: 30
+          elbLogsRetentionDays: 30
         },
         ecr: {
           imageRetentionCount: 20,


### PR DESCRIPTION
## Fix ELB S3 Log Delivery Access Denied Error

### Problem
ELB service unable to write access logs to S3 bucket due to missing ACL condition in bucket policy.

### Solution
Added required condition to S3 PutObject policy:
- `s3:x-amz-acl: bucket-owner-full-control` - Required by AWS ELB for log delivery

### Changes
- Updated `lib/constructs/services.ts` ELB bucket policy

Fixes error: `Access Denied for bucket: tak-demo-baseinfra-ap-southeast-2-648332710556-logs`
