### PR TITLE
Fix ELB Logs Bucket Naming Conflict

### DIFF
--- a/lib/constructs/services.ts
+++ b/lib/constructs/services.ts
@@ -97,7 +97,7 @@ export function createS3Resources(scope: Construct, stackName: string, region: s
 
   // ELB access logs bucket with globally unique naming (ALB and NLB)
   const elbLogsBucket = new s3.Bucket(scope, 'ElbLogsBucket', {
-    bucketName: `${stackName.toLowerCase()}-${region}-${cdk.Aws.ACCOUNT_ID}-logs`,
+    bucketName: `${stackName.toLowerCase()}-${region}-${cdk.Aws.ACCOUNT_ID}-elblogs`,
     removalPolicy: removalPolicy === 'RETAIN' ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY,
     autoDeleteObjects: removalPolicy !== 'RETAIN',
     lifecycleRules: [{


### PR DESCRIPTION
# Fix ELB Logs Bucket Naming Conflict

## Changes
- **Bucket name**: `...logs` → `...elblogs`
- **Pattern**: `{stack}-{region}-{account}-elblogs`
- Resolves conflict with existing bucket in stack

## Impact
Creates new bucket with unique name while preserving all ELB logging functionality.

## Breaking Changes
None - new bucket will be created automatically.
