### PR TITLE
Add Dual S3 Buckets for ALB/ELB Logs Migration

### DIFF
--- a/lib/base-infra-stack.ts
+++ b/lib/base-infra-stack.ts
@@ -51,7 +51,7 @@ export class BaseInfraStack extends cdk.Stack {
     const { ecsCluster } = createEcsResources(this, this.stackName, vpc);
     const { ecrRepo } = createEcrResources(this, this.stackName, imageRetentionCount, scanOnPush, removalPolicy);
     const { kmsKey, kmsAlias } = createKmsResources(this, this.stackName, enableKeyRotation, removalPolicy);
-    const { configBucket, envConfigBucket, appImagesBucket, elbLogsBucket } = createS3Resources(this, this.stackName, cdk.Stack.of(this).region, kmsKey, enableVersioning, removalPolicy, envConfig.s3.elbLogsRetentionDays);
+    const { configBucket, envConfigBucket, appImagesBucket, albLogsBucket, elbLogsBucket } = createS3Resources(this, this.stackName, cdk.Stack.of(this).region, kmsKey, enableVersioning, removalPolicy, envConfig.s3.elbLogsRetentionDays);
 
     // Endpoint Security Group (for interface endpoints)
     let endpointSg: ec2.SecurityGroup | undefined = undefined;
@@ -97,6 +97,7 @@ export class BaseInfraStack extends cdk.Stack {
       configBucket,
       envConfigBucket,
       appImagesBucket,
+      albLogsBucket,
       elbLogsBucket,
       vpcEndpoints,
       certificate,

--- a/lib/outputs.ts
+++ b/lib/outputs.ts
@@ -20,6 +20,7 @@ export interface OutputParams {
   configBucket: s3.Bucket;
   envConfigBucket: s3.Bucket;
   appImagesBucket: s3.Bucket;
+  albLogsBucket: s3.Bucket;
   elbLogsBucket: s3.Bucket;
   vpcEndpoints?: Record<string, ec2.GatewayVpcEndpoint | ec2.InterfaceVpcEndpoint>;
   certificate?: acm.Certificate;
@@ -48,7 +49,7 @@ export function registerOutputs(params: OutputParams): void {
     { key: 'S3TAKImagesArn', value: params.appImagesBucket.bucketArn, description: 'S3 TAK Images Bucket ARN' },
     { key: 'S3EnvConfigArn', value: params.envConfigBucket.bucketArn, description: 'S3 Environment Config Bucket ARN' },
     { key: 'S3ElbLogsArn', value: params.elbLogsBucket.bucketArn, description: 'S3 ELB Access Logs Bucket ARN' },
-    { key: 'S3AlbLogsArn', value: params.elbLogsBucket.bucketArn, description: 'S3 ALB Access Logs Bucket ARN (deprecated - use S3ElbLogsArn)' },
+    { key: 'S3AlbLogsArn', value: params.albLogsBucket.bucketArn, description: 'S3 ALB Access Logs Bucket ARN (deprecated - use S3ElbLogsArn)' },
 
   ];
 

--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
     "test:watch": "unset CDK_DEFAULT_ACCOUNT && unset CDK_DEFAULT_REGION && jest --watch",
     "test:coverage": "unset CDK_DEFAULT_ACCOUNT && unset CDK_DEFAULT_REGION && jest --coverage",
     
-    "deploy:dev": "npm run build && cdk deploy --context env=dev-test",
-    "deploy:prod": "npm run build && cdk deploy --context env=prod",
-    "synth:dev": "npm run build && cdk synth --context env=dev-test",
-    "synth:prod": "npm run build && cdk synth --context env=prod",
+    "deploy:dev": "npm run build && cdk deploy --context envType=dev-test",
+    "deploy:prod": "npm run build && cdk deploy --context envType=prod",
+    "synth:dev": "npm run build && cdk synth --context envType=dev-test",
+    "synth:prod": "npm run build && cdk synth --context envType=prod",
     
-    "cdk:diff:dev": "npm run build && cdk diff --context env=dev-test",
-    "cdk:diff:prod": "npm run build && cdk diff --context env=prod",
+    "cdk:diff:dev": "npm run build && cdk diff --context envType=dev-test",
+    "cdk:diff:prod": "npm run build && cdk diff --context envType=prod",
     "cdk:bootstrap": "cdk bootstrap"
   },
   "devDependencies": {

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -18,7 +18,7 @@ describe('AWS Resources', () => {
     template.resourceCountIs('AWS::ECR::Repository', 1);
     template.resourceCountIs('AWS::KMS::Key', 1);
     template.resourceCountIs('AWS::KMS::Alias', 1);
-    template.resourceCountIs('AWS::S3::Bucket', 4);
+    template.resourceCountIs('AWS::S3::Bucket', 5);
     template.resourceCountIs('AWS::CertificateManager::Certificate', 1);
     template.hasResourceProperties('AWS::S3::Bucket', {
       OwnershipControls: {


### PR DESCRIPTION
# Add Dual S3 Buckets for ALB/ELB Logs Migration

## Changes
- **Legacy bucket**: `albLogsBucket` with `-logs` suffix
- **New bucket**: `elbLogsBucket` with `-elblogs` suffix
- **Exports**: Both `S3AlbLogsArn` and `S3ElbLogsArn` available
- **Permissions**: Applied to both buckets identically

## Migration Strategy
1. Deploy with both buckets
2. Update dependent stacks to use `S3ElbLogsArn`
3. Remove legacy bucket in future PR

## Breaking Changes
None - maintains full backward compatibility.
