### PR TITLE
Add Partition-Aware ELB Service Account Filtering

### DIFF
--- a/cdk.context.json
+++ b/cdk.context.json
@@ -24,5 +24,14 @@
   "hosted-zone:account=814704514736:domainName=demo.tak.nz:privateZone=false:region=ap-southeast-2": {
     "Id": "/hostedzone/Z08334492PVCOLDAU1LDV",
     "Name": "demo.tak.nz."
+  },
+  "availability-zones:account=648332710556:region=ap-southeast-2": [
+    "ap-southeast-2a",
+    "ap-southeast-2b",
+    "ap-southeast-2c"
+  ],
+  "hosted-zone:account=648332710556:domainName=demo.tak.nz:privateZone=false:region=ap-southeast-2": {
+    "Id": "/hostedzone/Z07933942WE5FZIS9Y6DP",
+    "Name": "demo.tak.nz."
   }
 }

--- a/lib/base-infra-stack.ts
+++ b/lib/base-infra-stack.ts
@@ -51,7 +51,7 @@ export class BaseInfraStack extends cdk.Stack {
     const { ecsCluster } = createEcsResources(this, this.stackName, vpc);
     const { ecrRepo } = createEcrResources(this, this.stackName, imageRetentionCount, scanOnPush, removalPolicy);
     const { kmsKey, kmsAlias } = createKmsResources(this, this.stackName, enableKeyRotation, removalPolicy);
-    const { configBucket, envConfigBucket, appImagesBucket, albLogsBucket, elbLogsBucket } = createS3Resources(this, this.stackName, cdk.Stack.of(this).region, kmsKey, enableVersioning, removalPolicy, envConfig.s3.elbLogsRetentionDays);
+    const { envConfigBucket, appImagesBucket, elbLogsBucket } = createS3Resources(this, this.stackName, cdk.Stack.of(this).region, kmsKey, enableVersioning, removalPolicy, envConfig.s3.elbLogsRetentionDays);
 
     // Endpoint Security Group (for interface endpoints)
     let endpointSg: ec2.SecurityGroup | undefined = undefined;
@@ -94,10 +94,8 @@ export class BaseInfraStack extends cdk.Stack {
       ecrRepo,
       kmsKey,
       kmsAlias,
-      configBucket,
       envConfigBucket,
       appImagesBucket,
-      albLogsBucket,
       elbLogsBucket,
       vpcEndpoints,
       certificate,

--- a/lib/outputs.ts
+++ b/lib/outputs.ts
@@ -17,10 +17,8 @@ export interface OutputParams {
   ecrRepo: ecr.Repository;
   kmsKey: kms.Key;
   kmsAlias: kms.Alias;
-  configBucket: s3.Bucket;
   envConfigBucket: s3.Bucket;
   appImagesBucket: s3.Bucket;
-  albLogsBucket: s3.Bucket;
   elbLogsBucket: s3.Bucket;
   vpcEndpoints?: Record<string, ec2.GatewayVpcEndpoint | ec2.InterfaceVpcEndpoint>;
   certificate?: acm.Certificate;
@@ -45,11 +43,9 @@ export function registerOutputs(params: OutputParams): void {
     { key: 'EcrRepoArn', value: params.ecrRepo.repositoryArn, description: 'ECR Repository ARN' },
     { key: 'KmsKeyArn', value: params.kmsKey.keyArn, description: 'KMS Key ARN' },
     { key: 'KmsAlias', value: params.kmsAlias.aliasName, description: 'KMS Key Alias' },
-    { key: 'S3BucketArn', value: params.configBucket.bucketArn, description: 'S3 Configuration Bucket ARN' },
     { key: 'S3TAKImagesArn', value: params.appImagesBucket.bucketArn, description: 'S3 TAK Images Bucket ARN' },
     { key: 'S3EnvConfigArn', value: params.envConfigBucket.bucketArn, description: 'S3 Environment Config Bucket ARN' },
     { key: 'S3ElbLogsArn', value: params.elbLogsBucket.bucketArn, description: 'S3 ELB Access Logs Bucket ARN' },
-    { key: 'S3AlbLogsArn', value: params.albLogsBucket.bucketArn, description: 'S3 ALB Access Logs Bucket ARN (deprecated - use S3ElbLogsArn)' },
 
   ];
 
@@ -61,21 +57,14 @@ export function registerOutputs(params: OutputParams): void {
     });
   });
 
-  // Legacy ConfigBucket export (for migration)
-  new cdk.CfnOutput(stack, 'ConfigBucketOutput', {
-    value: params.configBucket.bucketName,
-    description: 'Legacy configuration bucket (deprecated)',
-    exportName: `${stackName}-ConfigBucket`,
-  });
-
-  // New EnvConfigBucket export
+  // EnvConfigBucket export
   new cdk.CfnOutput(stack, 'EnvConfigBucketOutput', {
     value: params.envConfigBucket.bucketName,
     description: 'Environment configuration bucket with globally unique naming',
     exportName: `${stackName}-EnvConfigBucket`,
   });
 
-  // AppImagesBucket export (updated with new naming)
+  // AppImagesBucket export
   new cdk.CfnOutput(stack, 'AppImagesBucketOutput', {
     value: params.appImagesBucket.bucketName,
     description: 'Application images bucket with globally unique naming',
@@ -88,9 +77,6 @@ export function registerOutputs(params: OutputParams): void {
     description: 'ELB access logs bucket with globally unique naming (ALB and NLB)',
     exportName: `${stackName}-ElbLogsBucket`,
   });
-
-
-
   // Conditional outputs
   if (params.ipv6CidrBlock && params.vpcLogicalId) {
     new cdk.CfnOutput(stack, 'VpcCidrIpv6Output', {

--- a/test/elb-partition.test.ts
+++ b/test/elb-partition.test.ts
@@ -1,0 +1,64 @@
+import { Template } from 'aws-cdk-lib/assertions';
+import { BaseInfraStack } from '../lib/base-infra-stack';
+import { createTestApp } from './utils';
+
+describe('ELB Service Account Partition Filtering', () => {
+  it('filters to commercial region principals only for commercial regions', () => {
+    const app = createTestApp();
+    const envConfig = app.node.tryGetContext('prod');
+    
+    const stack = new BaseInfraStack(app, 'TestStack', { 
+      environment: 'prod',
+      envConfig: envConfig,
+      env: { account: '123456789012', region: 'us-east-1' }
+    });
+    const template = Template.fromStack(stack);
+    
+    // Should have commercial ELB service account principals only
+    const bucketPolicies = template.findResources('AWS::S3::BucketPolicy');
+    const elbBucketPolicy = bucketPolicies['ElbLogsBucketPolicy90E80978'];
+    const principals = JSON.stringify(elbBucketPolicy);
+    
+    expect(principals).toContain('arn:aws:iam::');
+    expect(principals).not.toContain('arn:aws-us-gov:iam::');
+  });
+
+  it('filters to GovCloud region principals only for GovCloud regions', () => {
+    const app = createTestApp();
+    const envConfig = app.node.tryGetContext('prod');
+    
+    const stack = new BaseInfraStack(app, 'TestStack', { 
+      environment: 'prod',
+      envConfig: envConfig,
+      env: { account: '123456789012', region: 'us-gov-west-1' }
+    });
+    const template = Template.fromStack(stack);
+    
+    // Should have GovCloud ELB service account principals only
+    const bucketPolicies = template.findResources('AWS::S3::BucketPolicy');
+    const elbBucketPolicy = bucketPolicies['ElbLogsBucketPolicy90E80978'];
+    const principals = JSON.stringify(elbBucketPolicy);
+    
+    expect(principals).toContain('arn:aws-us-gov:iam::');
+    expect(principals).not.toContain('arn:aws:iam::');
+  });
+
+  it('does not mix commercial and GovCloud principals', () => {
+    const app = createTestApp();
+    const envConfig = app.node.tryGetContext('prod');
+    
+    const stack = new BaseInfraStack(app, 'TestStack', { 
+      environment: 'prod',
+      envConfig: envConfig,
+      env: { account: '123456789012', region: 'us-east-1' }
+    });
+    const template = Template.fromStack(stack);
+    
+    // Should not have GovCloud principals in commercial region deployment
+    const bucketPolicies = template.findResources('AWS::S3::BucketPolicy');
+    const policyStatements = JSON.stringify(bucketPolicies);
+    
+    expect(policyStatements).not.toContain('arn:aws-us-gov:iam::');
+    expect(policyStatements).toContain('arn:aws:iam::');
+  });
+});

--- a/test/outputs.test.ts
+++ b/test/outputs.test.ts
@@ -18,7 +18,7 @@ describe('Stack Outputs', () => {
       'VpcIdOutput', 'VpcCidrIpv4Output',
       'SubnetPublicAOutput', 'SubnetPublicBOutput', 'SubnetPrivateAOutput', 'SubnetPrivateBOutput',
       'EcsClusterArnOutput', 'EcrRepoArnOutput', 'KmsKeyArnOutput', 'KmsAliasOutput',
-      'ConfigBucketOutput', 'EnvConfigBucketOutput', 'AppImagesBucketOutput',
+      'EnvConfigBucketOutput', 'AppImagesBucketOutput', 'ElbLogsBucketOutput',
       'CertificateArnOutput', 'HostedZoneIdOutput', 'HostedZoneNameOutput'
     ].forEach(name => {
       expect(outputs[name]).toBeDefined();

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -18,7 +18,7 @@ describe('AWS Resources', () => {
     template.resourceCountIs('AWS::ECR::Repository', 1);
     template.resourceCountIs('AWS::KMS::Key', 1);
     template.resourceCountIs('AWS::KMS::Alias', 1);
-    template.resourceCountIs('AWS::S3::Bucket', 5);
+    template.resourceCountIs('AWS::S3::Bucket', 3);
     template.resourceCountIs('AWS::CertificateManager::Certificate', 1);
     template.hasResourceProperties('AWS::S3::Bucket', {
       OwnershipControls: {


### PR DESCRIPTION
# Add Partition-Aware ELB Service Account Filtering

## Changes
- **Partition filtering**: Separate commercial and GovCloud ELB service accounts
- **Service principals**: Added `delivery.logs.amazonaws.com` and `logdelivery.elasticloadbalancing.amazonaws.com`
- **Legacy cleanup**: Removed `configBucket` and `albLogsBucket`
- **Tests**: Added partition filtering test suite

## Problem Solved
Fixes "Invalid principal in policy" error caused by mixing commercial and GovCloud ARN formats in S3 bucket policies.

## Breaking Changes
Legacy S3 bucket exports removed - dependent stacks already updated.
