### PR TITLE
Fix: GitHub Workflow Bash Syntax Error

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -51,7 +51,8 @@ jobs:
       - name: Validate Change Set
         run: |
           # Check if override is requested
-          if [[ "${{ github.event.head_commit.message }}" == *"[force-deploy]"* ]]; then
+          COMMIT_MSG="${{ github.event.head_commit.message }}"
+          if [[ "$COMMIT_MSG" == *"[force-deploy]"* ]]; then
             echo "🚨 Force deploy detected - skipping change set validation"
           else
             ./scripts/github/validate-changeset.sh TAK-${{ vars.STACK_NAME }}-BaseInfra

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -56,7 +56,8 @@ jobs:
       - name: Validate Production Change Set
         run: |
           # Check if override is requested
-          if [[ "${{ github.event.head_commit.message }}" == *"[force-deploy]"* ]]; then
+          COMMIT_MSG="${{ github.event.head_commit.message }}"
+          if [[ "$COMMIT_MSG" == *"[force-deploy]"* ]]; then
             echo "🚨 Force deploy detected - skipping change set validation"
           else
             # Use stack name from tag or default


### PR DESCRIPTION
# Fix: GitHub Workflow Bash Syntax Error

## Problem
GitHub workflows failing with "conditional binary operator expected" when commit messages contain newlines.

## Solution
- Store commit message in variable before using in `[[ ]]` condition
- Prevents bash syntax errors from multiline strings
- Applied to both production and demo deploy workflows

## Files Changed
- `.github/workflows/production-deploy.yml`
- `.github/workflows/demo-deploy.yml`

## Testing
- [x] Syntax validation passes
- [x] Workflows handle multiline commit messages correctly
