### PR TITLE
Add KMS-Encrypted ECR Repositories for Artifacts and ETL Tasks

### DIFF
--- a/lib/base-infra-stack.ts
+++ b/lib/base-infra-stack.ts
@@ -49,8 +49,8 @@ export class BaseInfraStack extends cdk.Stack {
     // Create AWS resources
     const { vpc, ipv6CidrBlock, vpcLogicalId } = createVpcL2Resources(this, vpcCidr, enableRedundantNatGateways);
     const { ecsCluster } = createEcsResources(this, this.stackName, vpc);
-    const { ecrRepo } = createEcrResources(this, this.stackName, imageRetentionCount, scanOnPush, removalPolicy);
     const { kmsKey, kmsAlias } = createKmsResources(this, this.stackName, enableKeyRotation, removalPolicy);
+    const { ecrRepo, ecrArtifactsRepo, ecrEtlTasksRepo } = createEcrResources(this, this.stackName, imageRetentionCount, scanOnPush, removalPolicy, kmsKey);
     const { envConfigBucket, appImagesBucket, elbLogsBucket } = createS3Resources(this, this.stackName, cdk.Stack.of(this).region, kmsKey, enableVersioning, removalPolicy, envConfig.s3.elbLogsRetentionDays);
 
     // Endpoint Security Group (for interface endpoints)
@@ -92,6 +92,8 @@ export class BaseInfraStack extends cdk.Stack {
       vpcLogicalId,
       ecsCluster,
       ecrRepo,
+      ecrArtifactsRepo,
+      ecrEtlTasksRepo,
       kmsKey,
       kmsAlias,
       envConfigBucket,

--- a/lib/outputs.ts
+++ b/lib/outputs.ts
@@ -15,6 +15,8 @@ export interface OutputParams {
   vpcLogicalId?: string;
   ecsCluster: ecs.Cluster;
   ecrRepo: ecr.Repository;
+  ecrArtifactsRepo: ecr.Repository;
+  ecrEtlTasksRepo: ecr.Repository;
   kmsKey: kms.Key;
   kmsAlias: kms.Alias;
   envConfigBucket: s3.Bucket;
@@ -41,6 +43,8 @@ export function registerOutputs(params: OutputParams): void {
     { key: 'SubnetPrivateB', value: params.vpc.privateSubnets[1].subnetId, description: 'Subnet Private B' },
     { key: 'EcsClusterArn', value: params.ecsCluster.clusterArn, description: 'ECS Cluster ARN' },
     { key: 'EcrRepoArn', value: params.ecrRepo.repositoryArn, description: 'ECR Repository ARN' },
+    { key: 'EcrArtifactsRepoArn', value: params.ecrArtifactsRepo.repositoryArn, description: 'ECR Artifacts Repository ARN' },
+    { key: 'EcrEtlTasksRepoArn', value: params.ecrEtlTasksRepo.repositoryArn, description: 'ECR ETL Tasks Repository ARN' },
     { key: 'KmsKeyArn', value: params.kmsKey.keyArn, description: 'KMS Key ARN' },
     { key: 'KmsAlias', value: params.kmsAlias.aliasName, description: 'KMS Key Alias' },
     { key: 'S3TAKImagesArn', value: params.appImagesBucket.bucketArn, description: 'S3 TAK Images Bucket ARN' },

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -15,7 +15,7 @@ describe('AWS Resources', () => {
     });
     const template = Template.fromStack(stack);
     template.resourceCountIs('AWS::ECS::Cluster', 1);
-    template.resourceCountIs('AWS::ECR::Repository', 1);
+    template.resourceCountIs('AWS::ECR::Repository', 3);
     template.resourceCountIs('AWS::KMS::Key', 1);
     template.resourceCountIs('AWS::KMS::Alias', 1);
     template.resourceCountIs('AWS::S3::Bucket', 3);


### PR DESCRIPTION
# Add KMS-Encrypted ECR Repositories for Artifacts and ETL Tasks

## Summary
Adds two new KMS-encrypted ECR repositories while preserving the existing ECR repository unchanged.

## Changes
- **New ECR Repositories:**
  - `tak-{envName}-artifacts` 
  - `tak-{envName}-etltasks`
- **Security:** All ECR repositories now use KMS encryption with existing KMS key
- **Configuration:** New repositories inherit same lifecycle policies and context settings
- **Exports:** Added CloudFormation outputs for new repositories
- **Tests:** Updated resource count validation

## Repository Names
- Dev: `tak-dev-artifacts`, `tak-dev-etltasks`
- Prod: `tak-prod-artifacts`, `tak-prod-etltasks`

## CloudFormation Exports
- `{StackName}-EcrArtifactsRepoArn`
- `{StackName}-EcrEtlTasksRepoArn`
