### PR TITLE
Fix ECR Replacement Issue and Improve Breaking Change Detection

### DIFF
--- a/lib/constructs/services.ts
+++ b/lib/constructs/services.ts
@@ -22,8 +22,6 @@ export function createEcrResources(scope: Construct, stackName: string, imageRet
     repositoryName: stackName.toLowerCase(),
     imageScanOnPush: scanOnPush,
     imageTagMutability: ecr.TagMutability.MUTABLE,
-    encryption: ecr.RepositoryEncryption.KMS,
-    encryptionKey: kmsKey,
     lifecycleRules: [{
       maxImageCount: imageRetentionCount,
     }, {

--- a/scripts/github/check-breaking-changes.sh
+++ b/scripts/github/check-breaking-changes.sh
@@ -15,6 +15,8 @@ case $STACK_TYPE in
       "HostedZone.*will be destroyed"
       "ECSCluster.*will be destroyed"
       "S3.*Bucket.*will be destroyed"
+      "ECRRepo.*must be replaced"
+      "Repository.*must be replaced"
     )
     ;;
   "auth")


### PR DESCRIPTION
# Fix ECR Replacement Issue and Improve Breaking Change Detection

## Problem
CDK deploy failed because adding KMS encryption to existing ECR repository requires replacement, which CloudFormation cannot do with custom-named resources.

## Solution
- **Existing ECR:** Remove encryption to prevent replacement
- **New ECRs:** Keep KMS encryption as planned
- **Detection:** Add replacement patterns to breaking change script

## Changes
- Remove `encryption` and `encryptionKey` from existing ECR repository
- Add ECR replacement detection patterns to `check-breaking-changes.sh`

## Result
- Existing ECR repository unchanged (no replacement)
- New repositories still get KMS encryption
- Future ECR changes will be caught by CI checks
