### PR TITLE
Fix ELB Logs Bucket Auto-Delete Permission Error

### DIFF
--- a/lib/constructs/services.ts
+++ b/lib/constructs/services.ts
@@ -203,6 +203,7 @@ export function createS3Resources(scope: Construct, stackName: string, region: s
       principals: [new AccountRootPrincipal()],
       actions: [
         's3:GetBucketAcl',
+        's3:GetBucketTagging',
         's3:PutObject'
       ],
       resources: [bucket.bucketArn, `${bucket.bucketArn}/*`]


### PR DESCRIPTION
# Fix ELB Logs Bucket Auto-Delete Permission Error

## Problem
Stack deletion failed with AccessDenied error - auto-delete Lambda missing `s3:GetBucketTagging` permission on ELB logs bucket.

## Solution
Add `s3:GetBucketTagging` to existing bucket policy for account root principal.

## Changes
- Add `s3:GetBucketTagging` action to ELB logs bucket resource policy

## Result
Stack deletion will complete successfully without permission errors.
