### PR TITLE
Add Lambda Service Policies to ECR Repositories

### DIFF
--- a/lib/constructs/services.ts
+++ b/lib/constructs/services.ts
@@ -46,6 +46,16 @@ export function createEcrResources(scope: Construct, stackName: string, imageRet
     removalPolicy: removalPolicy === 'RETAIN' ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY,
   });
 
+  ecrArtifactsRepo.addToResourcePolicy(new cdk.aws_iam.PolicyStatement({
+    effect: cdk.aws_iam.Effect.ALLOW,
+    principals: [new cdk.aws_iam.ServicePrincipal('lambda.amazonaws.com')],
+    actions: [
+      'ecr:BatchCheckLayerAvailability',
+      'ecr:GetDownloadUrlForLayer',
+      'ecr:BatchGetImage'
+    ]
+  }));
+
   const ecrEtlTasksRepo = new ecr.Repository(scope, 'ECREtlTasksRepo', {
     repositoryName: `tak-${stackName.toLowerCase()}-etltasks`,
     imageScanOnPush: scanOnPush,


### PR DESCRIPTION
## Add Lambda Service Policies to ECR Repositories

### Summary
Added resource policies to both `ECRArtifactsRepo` and `ECREtlTasksRepo` allowing Lambda service to pull container images.

### Changes
- Added IAM policy statements to ECR artifacts and ETL tasks repositories
- Grants Lambda service permissions for:
  - `ecr:BatchCheckLayerAvailability`
  - `ecr:GetDownloadUrlForLayer` 
  - `ecr:BatchGetImage`

### Impact
Enables Lambda functions to pull images from both ECR repositories for serverless container execution.
