### PR TITLE
Fix npm clean script to remove all compiled files

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "watch": "tsc -w",
     "test": "unset CDK_DEFAULT_ACCOUNT && unset CDK_DEFAULT_REGION && jest",
     "cdk": "cdk",
-    "clean": "rm -f bin/*.js bin/*.d.ts lib/*.js lib/*.d.ts test/*.js test/*.d.ts; rm -rf cdk.out/*",
+    "clean": "find bin lib test -name '*.js' -o -name '*.d.ts' | xargs rm -f; rm -rf cdk.out/*",
     
     "dev": "npm run build && npm run test",
     "test:watch": "unset CDK_DEFAULT_ACCOUNT && unset CDK_DEFAULT_REGION && jest --watch",


### PR DESCRIPTION
## Fix npm clean script to remove all compiled files

### Summary
Updated the `clean` script to recursively remove compiled TypeScript files from all subdirectories.

### Problem
The previous clean script only removed `.js` and `.d.ts` files from the root of `bin/`, `lib/`, and `test/` directories, leaving compiled files in subdirectories like `lib/constructs/` and `lib/utils/`.

### Solution
- Replaced glob patterns with `find` command to recursively locate all compiled files
- Ensures complete cleanup of all TypeScript compilation artifacts

### Impact
`npm run clean` now properly removes all compiled files, preventing stale build artifacts.
