### PR TITLE
## Fix S3 Auto-Delete Custom Resource Permissions

### DIFF
--- a/lib/constructs/services.ts
+++ b/lib/constructs/services.ts
@@ -224,7 +224,9 @@ export function createS3Resources(scope: Construct, stackName: string, region: s
       actions: [
         's3:GetBucketAcl',
         's3:GetBucketTagging',
-        's3:PutObject'
+        's3:PutObject',
+        's3:ListBucket',
+        's3:DeleteObject'
       ],
       resources: [bucket.bucketArn, `${bucket.bucketArn}/*`]
     }));


### PR DESCRIPTION

### Solution
- Added `s3:ListBucket` permission for bucket enumeration
- Added `s3:DeleteObject` permission for object cleanup
- Existing `s3:GetBucketTagging` permission was already present

### Impact
- Fixes stack deletion failures
- Enables proper cleanup of ELB logs bucket during stack removal
- Resolves auto-delete custom resource permission issues
