### PR TITLE
Add media-infra to GitHub OIDC Configuration

### DIFF
--- a/docs/AWS_GITHUB_SETUP.md
+++ b/docs/AWS_GITHUB_SETUP.md
@@ -173,7 +173,9 @@ cat > prod-github-trust-policy.json << 'EOF'
           "token.actions.githubusercontent.com:sub": [
             "repo:TAK-NZ/base-infra:environment:production",
             "repo:TAK-NZ/auth-infra:environment:production",
-            "repo:TAK-NZ/tak-infra:environment:production"
+            "repo:TAK-NZ/tak-infra:environment:production",
+            "repo:TAK-NZ/CloudTAK:environment:production",
+            "repo:TAK-NZ/media-infra:environment:production"
           ]
         }
       }
@@ -211,7 +213,9 @@ cat > demo-github-trust-policy.json << 'EOF'
           "token.actions.githubusercontent.com:sub": [
             "repo:TAK-NZ/base-infra:environment:demo",
             "repo:TAK-NZ/auth-infra:environment:demo",
-            "repo:TAK-NZ/tak-infra:environment:demo"
+            "repo:TAK-NZ/tak-infra:environment:demo",
+            "repo:TAK-NZ/CloudTAK:environment:demo",
+            "repo:TAK-NZ/media-infra:environment:demo"
           ]
         }
       }


### PR DESCRIPTION
## Add media-infra to GitHub OIDC Configuration

### Summary
Updated the AWS GitHub OIDC setup documentation to include the `media-infra` repository in the trust policies for both production and demo environments.

### Changes
- Added `repo:TAK-NZ/media-infra:environment:production` to production trust policy
- Added `repo:TAK-NZ/media-infra:environment:demo` to demo trust policy

### Impact
- Enables GitHub Actions in the media-infra repository to deploy to AWS environments
- Maintains consistency with other TAK-NZ infrastructure repositories
- Supports the complete TAK infrastructure deployment pipeline
