### PR TITLE
Remove Unused ECR Repository and Fix Lifecycle Rules

### DIFF
--- a/lib/base-infra-stack.ts
+++ b/lib/base-infra-stack.ts
@@ -50,7 +50,7 @@ export class BaseInfraStack extends cdk.Stack {
     const { vpc, ipv6CidrBlock, vpcLogicalId } = createVpcL2Resources(this, vpcCidr, enableRedundantNatGateways);
     const { ecsCluster } = createEcsResources(this, this.stackName, vpc);
     const { kmsKey, kmsAlias } = createKmsResources(this, this.stackName, enableKeyRotation, removalPolicy);
-    const { ecrRepo, ecrArtifactsRepo, ecrEtlTasksRepo } = createEcrResources(this, this.stackName, imageRetentionCount, scanOnPush, removalPolicy, kmsKey);
+    const { ecrArtifactsRepo, ecrEtlTasksRepo } = createEcrResources(this, this.stackName, imageRetentionCount, scanOnPush, removalPolicy, kmsKey);
     const { envConfigBucket, appImagesBucket, elbLogsBucket } = createS3Resources(this, this.stackName, cdk.Stack.of(this).region, kmsKey, enableVersioning, removalPolicy, envConfig.s3.elbLogsRetentionDays);
 
     // Endpoint Security Group (for interface endpoints)
@@ -91,7 +91,7 @@ export class BaseInfraStack extends cdk.Stack {
       ipv6CidrBlock,
       vpcLogicalId,
       ecsCluster,
-      ecrRepo,
+
       ecrArtifactsRepo,
       ecrEtlTasksRepo,
       kmsKey,

--- a/lib/constructs/services.ts
+++ b/lib/constructs/services.ts
@@ -18,31 +18,22 @@ export function createEcsResources(scope: Construct, stackName: string, vpc: ec2
 }
 
 export function createEcrResources(scope: Construct, stackName: string, imageRetentionCount: number, scanOnPush: boolean, removalPolicy: string, kmsKey: kms.Key) {
-  const ecrRepo = new ecr.Repository(scope, 'ECRRepo', {
-    repositoryName: stackName.toLowerCase(),
-    imageScanOnPush: scanOnPush,
-    imageTagMutability: ecr.TagMutability.MUTABLE,
-    lifecycleRules: [{
-      maxImageCount: imageRetentionCount,
-    }, {
-      tagStatus: ecr.TagStatus.UNTAGGED,
-      maxImageAge: cdk.Duration.days(1),
-    }],
-    removalPolicy: removalPolicy === 'RETAIN' ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY,
-  });
-
   const ecrArtifactsRepo = new ecr.Repository(scope, 'ECRArtifactsRepo', {
     repositoryName: `${stackName.toLowerCase()}-artifacts`,
     imageScanOnPush: scanOnPush,
     imageTagMutability: ecr.TagMutability.MUTABLE,
     encryption: ecr.RepositoryEncryption.KMS,
     encryptionKey: kmsKey,
-    lifecycleRules: [{
-      maxImageCount: imageRetentionCount,
-    }, {
-      tagStatus: ecr.TagStatus.UNTAGGED,
-      maxImageAge: cdk.Duration.days(1),
-    }],
+    lifecycleRules: [
+      { tagPrefixList: ['tak-'], maxImageCount: imageRetentionCount },
+      { tagPrefixList: ['authentik-'], maxImageCount: imageRetentionCount },
+      { tagPrefixList: ['ldap-'], maxImageCount: imageRetentionCount },
+      { tagPrefixList: ['pmtiles-'], maxImageCount: imageRetentionCount },
+      { tagPrefixList: ['events-'], maxImageCount: imageRetentionCount },
+      { tagPrefixList: ['data-'], maxImageCount: imageRetentionCount },
+      { tagPrefixList: ['cloudtak-'], maxImageCount: imageRetentionCount },
+      { tagStatus: ecr.TagStatus.UNTAGGED, maxImageAge: cdk.Duration.days(1) }
+    ],
     removalPolicy: removalPolicy === 'RETAIN' ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY,
   });
 
@@ -62,12 +53,10 @@ export function createEcrResources(scope: Construct, stackName: string, imageRet
     imageTagMutability: ecr.TagMutability.MUTABLE,
     encryption: ecr.RepositoryEncryption.KMS,
     encryptionKey: kmsKey,
-    lifecycleRules: [{
-      maxImageCount: imageRetentionCount,
-    }, {
-      tagStatus: ecr.TagStatus.UNTAGGED,
-      maxImageAge: cdk.Duration.days(1),
-    }],
+    lifecycleRules: [
+      { tagPrefixList: ['etl-'], maxImageCount: imageRetentionCount },
+      { tagStatus: ecr.TagStatus.UNTAGGED, maxImageAge: cdk.Duration.days(1) }
+    ],
     removalPolicy: removalPolicy === 'RETAIN' ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY,
   });
 
@@ -81,7 +70,7 @@ export function createEcrResources(scope: Construct, stackName: string, imageRet
     ]
   }));
 
-  return { ecrRepo, ecrArtifactsRepo, ecrEtlTasksRepo };
+  return { ecrArtifactsRepo, ecrEtlTasksRepo };
 }
 
 export function createKmsResources(scope: Construct, stackName: string, enableKeyRotation: boolean, removalPolicy: string) {

--- a/lib/outputs.ts
+++ b/lib/outputs.ts
@@ -14,7 +14,7 @@ export interface OutputParams {
   ipv6CidrBlock?: ec2.CfnVPCCidrBlock;
   vpcLogicalId?: string;
   ecsCluster: ecs.Cluster;
-  ecrRepo: ecr.Repository;
+
   ecrArtifactsRepo: ecr.Repository;
   ecrEtlTasksRepo: ecr.Repository;
   kmsKey: kms.Key;
@@ -42,7 +42,7 @@ export function registerOutputs(params: OutputParams): void {
     { key: 'SubnetPrivateA', value: params.vpc.privateSubnets[0].subnetId, description: 'Subnet Private A' },
     { key: 'SubnetPrivateB', value: params.vpc.privateSubnets[1].subnetId, description: 'Subnet Private B' },
     { key: 'EcsClusterArn', value: params.ecsCluster.clusterArn, description: 'ECS Cluster ARN' },
-    { key: 'EcrRepoArn', value: params.ecrRepo.repositoryArn, description: 'ECR Repository ARN' },
+
     { key: 'EcrArtifactsRepoArn', value: params.ecrArtifactsRepo.repositoryArn, description: 'ECR Artifacts Repository ARN' },
     { key: 'EcrEtlTasksRepoArn', value: params.ecrEtlTasksRepo.repositoryArn, description: 'ECR ETL Tasks Repository ARN' },
     { key: 'KmsKeyArn', value: params.kmsKey.keyArn, description: 'KMS Key ARN' },

--- a/test/outputs.test.ts
+++ b/test/outputs.test.ts
@@ -17,7 +17,7 @@ describe('Stack Outputs', () => {
     [
       'VpcIdOutput', 'VpcCidrIpv4Output',
       'SubnetPublicAOutput', 'SubnetPublicBOutput', 'SubnetPrivateAOutput', 'SubnetPrivateBOutput',
-      'EcsClusterArnOutput', 'EcrRepoArnOutput', 'KmsKeyArnOutput', 'KmsAliasOutput',
+      'EcsClusterArnOutput', 'KmsKeyArnOutput', 'KmsAliasOutput',
       'EnvConfigBucketOutput', 'AppImagesBucketOutput', 'ElbLogsBucketOutput',
       'CertificateArnOutput', 'HostedZoneIdOutput', 'HostedZoneNameOutput'
     ].forEach(name => {

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -15,7 +15,7 @@ describe('AWS Resources', () => {
     });
     const template = Template.fromStack(stack);
     template.resourceCountIs('AWS::ECS::Cluster', 1);
-    template.resourceCountIs('AWS::ECR::Repository', 3);
+    template.resourceCountIs('AWS::ECR::Repository', 2);
     template.resourceCountIs('AWS::KMS::Key', 1);
     template.resourceCountIs('AWS::KMS::Alias', 1);
     template.resourceCountIs('AWS::S3::Bucket', 3);


### PR DESCRIPTION
## Remove Unused ECR Repository and Fix Lifecycle Rules

### Summary
Removed the unused `ECRRepo` repository and fixed ECR lifecycle rules to properly manage image retention per tag prefix instead of globally.

### Changes Made

#### ECR Repository Removal
- Removed `ECRRepo` from `createEcrResources` function
- Updated return statement to only include `ecrArtifactsRepo` and `ecrEtlTasksRepo`
- Removed `ecrRepo` from `OutputParams` interface and stack outputs
- Updated stack configuration to remove ECRRepo references

#### ECR Lifecycle Rules Fix
- **ECRArtifactsRepo**: Added separate rules for each image prefix:
  - `tak-`, `authentik-`, `ldap-`, `pmtiles-`, `events-`, `data-`, `cloudtak-`
  - Each prefix now retains `imageRetentionCount` images independently
- **ECREtlTasksRepo**: Added rule for `etl-` prefix
- Maintains existing untagged image cleanup (1 day retention)

#### Test Updates
- Updated `resources.test.ts`: ECR repository count from 3 to 2
- Updated `outputs.test.ts`: Removed `EcrRepoArnOutput` from expected outputs

### Impact
- **Before**: Total of 5 images across all types (broken behavior)
- **After**: Up to 35 images in artifacts repo (5 per prefix) + 5 in ETL repo
- Proper image retention per application type
- Cleaner infrastructure with unused resources removed

### Breaking Change
⚠️ **This removes an ECR repository** - Ensure no services are referencing the removed `ECRRepo` before deployment.
