### PR TITLE
Add Specific ETL Image Prefixes to ECR Lifecycle Rules

### DIFF
--- a/lib/constructs/services.ts
+++ b/lib/constructs/services.ts
@@ -54,7 +54,10 @@ export function createEcrResources(scope: Construct, stackName: string, imageRet
     encryption: ecr.RepositoryEncryption.KMS,
     encryptionKey: kmsKey,
     lifecycleRules: [
-      { tagPrefixList: ['etl-'], maxImageCount: imageRetentionCount },
+      { tagPrefixList: ['etl-adsbx-'], maxImageCount: imageRetentionCount },
+      { tagPrefixList: ['etl-earthquakes-'], maxImageCount: imageRetentionCount },
+      { tagPrefixList: ['etl-geojson-'], maxImageCount: imageRetentionCount },
+      { tagPrefixList: ['etl-inreach-'], maxImageCount: imageRetentionCount },
       { tagStatus: ecr.TagStatus.UNTAGGED, maxImageAge: cdk.Duration.days(1) }
     ],
     removalPolicy: removalPolicy === 'RETAIN' ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY,


### PR DESCRIPTION
## Add Specific ETL Image Prefixes to ECR Lifecycle Rules

### Summary
Added dedicated ECR lifecycle rules for specific ETL image types to ensure proper retention management per ETL service.

### Changes
- Added `etl-earthquakes-` prefix for earthquake data ETL images
- Added `etl-adsbx-` prefix for ADS-B Exchange ETL images  
- Added `etl-geojson-` prefix for GeoJSON processing ETL images
- Added `etl-inreach-` prefix for Garmin InReach ETL images  
- Each prefix maintains `imageRetentionCount` images independently

### Impact
- **Before**: Single `etl-` prefix covering all ETL images
- **After**: Separate retention for each ETL service type
- Total capacity: Up to 15 ETL images (5 per service type)
- Better organization and retention management for different ETL workflows
