### PR TITLE
Migrate to Organization Secrets and Variables

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -38,15 +38,15 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.DEMO_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.DEMO_AWS_REGION }}
           role-session-name: GitHubActions-Demo
 
       - name: Install dependencies
         run: npm ci
 
       - name: Validate CDK Synthesis (Prod Profile)
-        run: npm run cdk synth -- --context envType=prod --context stackName=${{ vars.STACK_NAME }} --context r53ZoneName=${{ vars.R53_ZONE_NAME }}
+        run: npm run cdk synth -- --context envType=prod --context stackName=${{ vars.DEMO_STACK_NAME }} --context r53ZoneName=${{ vars.DEMO_R53_ZONE_NAME }}
 
       - name: Validate Change Set
         run: |
@@ -55,25 +55,25 @@ jobs:
           if [[ "$COMMIT_MSG" == *"[force-deploy]"* ]]; then
             echo "🚨 Force deploy detected - skipping change set validation"
           else
-            ./scripts/github/validate-changeset.sh TAK-${{ vars.STACK_NAME }}-BaseInfra
+            ./scripts/github/validate-changeset.sh TAK-${{ vars.DEMO_STACK_NAME }}-BaseInfra
           fi
 
       - name: Deploy Demo with Prod Profile
-        run: npm run cdk deploy -- --context envType=prod --context stackName=${{ vars.STACK_NAME }} --context r53ZoneName=${{ vars.R53_ZONE_NAME }} --require-approval never
+        run: npm run cdk deploy -- --context envType=prod --context stackName=${{ vars.DEMO_STACK_NAME }} --context r53ZoneName=${{ vars.DEMO_R53_ZONE_NAME }} --require-approval never
 
       - name: Wait for Testing Period
-        run: sleep ${{ vars.DEMO_TEST_DURATION || '300' }}
+        run: sleep ${{ vars.DEMO_TEST_DURATION }}
 
       - name: Run Automated Tests
         run: |
           echo "Placeholder for automated tests"
           # TODO: Add health checks and integration tests
-          # curl -f https://${{ vars.R53_ZONE_NAME }}/health || exit 1
+          # curl -f https://${{ vars.DEMO_R53_ZONE_NAME }}/health || exit 1
 
       - name: Validate CDK Synthesis (Dev-Test Profile)
-        run: npm run cdk synth -- --context envType=dev-test --context stackName=${{ vars.STACK_NAME }} --context r53ZoneName=${{ vars.R53_ZONE_NAME }}
+        run: npm run cdk synth -- --context envType=dev-test --context stackName=${{ vars.DEMO_STACK_NAME }} --context r53ZoneName=${{ vars.DEMO_R53_ZONE_NAME }}
         if: always()
 
       - name: Revert Demo to Dev-Test Profile
-        run: npm run cdk deploy -- --context envType=dev-test --context stackName=${{ vars.STACK_NAME }} --context r53ZoneName=${{ vars.R53_ZONE_NAME }} --require-approval never
+        run: npm run cdk deploy -- --context envType=dev-test --context stackName=${{ vars.DEMO_STACK_NAME }} --context r53ZoneName=${{ vars.DEMO_R53_ZONE_NAME }} --require-approval never
         if: always()

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.PROD_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.PROD_AWS_REGION }}
           role-session-name: GitHubActions-Production
 
       - name: Install dependencies
@@ -50,7 +50,7 @@ jobs:
       - name: Bootstrap CDK (if needed)
         run: |
           if ! aws cloudformation describe-stacks --stack-name CDKToolkit 2>/dev/null; then
-            npx cdk bootstrap aws://${{ secrets.AWS_ACCOUNT_ID }}/${{ secrets.AWS_REGION }} --context envType=prod
+            npx cdk bootstrap aws://${{ secrets.PROD_AWS_ACCOUNT_ID }}/${{ secrets.PROD_AWS_REGION }} --context envType=prod
           fi
 
       - name: Validate Production Change Set

--- a/docs/AWS_GITHUB_SETUP.md
+++ b/docs/AWS_GITHUB_SETUP.md
@@ -175,7 +175,8 @@ cat > prod-github-trust-policy.json << 'EOF'
             "repo:TAK-NZ/auth-infra:environment:production",
             "repo:TAK-NZ/tak-infra:environment:production",
             "repo:TAK-NZ/CloudTAK:environment:production",
-            "repo:TAK-NZ/media-infra:environment:production"
+            "repo:TAK-NZ/media-infra:environment:production",
+            "repo:TAK-NZ/etl-*:environment:production"
           ]
         }
       }
@@ -215,7 +216,8 @@ cat > demo-github-trust-policy.json << 'EOF'
             "repo:TAK-NZ/auth-infra:environment:demo",
             "repo:TAK-NZ/tak-infra:environment:demo",
             "repo:TAK-NZ/CloudTAK:environment:demo",
-            "repo:TAK-NZ/media-infra:environment:demo"
+            "repo:TAK-NZ/media-infra:environment:demo",
+            "repo:TAK-NZ/etl-*:environment:demo"
           ]
         }
       }
@@ -368,32 +370,35 @@ In your GitHub repository, go to **Settings → Environments** and create:
        - BaseInfra: `R53_ZONE_NAME`: `demo.tak.nz`
        - AuthInfra: `AUTHENTIK_ADMIN_EMAIL`: `admin@tak.nz`
 
-### 3.2 Configure Environment Secrets
+### 3.2 Configure Organization Secrets
 
-**For `production` environment:**
-- `AWS_ACCOUNT_ID`: `111111111111`
-- `AWS_ROLE_ARN`: `arn:aws:iam::111111111111:role/GitHubActions-TAK-Role`
-- `AWS_REGION`: `ap-southeast-6`
+**Create the following organization secrets:**
+- `DEMO_AWS_ACCOUNT_ID`: `222222222222`
+- `DEMO_AWS_REGION`: `ap-southeast-2`
+- `DEMO_AWS_ROLE_ARN`: `arn:aws:iam::222222222222:role/GitHubActions-TAK-Role`
+- `PROD_AWS_ACCOUNT_ID`: `111111111111`
+- `PROD_AWS_REGION`: `ap-southeast-6`
+- `PROD_AWS_ROLE_ARN`: `arn:aws:iam::111111111111:role/GitHubActions-TAK-Role`
 
-**For `demo` environment:**
-- `AWS_ACCOUNT_ID`: `222222222222`
-- `AWS_ROLE_ARN`: `arn:aws:iam::222222222222:role/GitHubActions-TAK-Role`
-- `AWS_REGION`: `ap-southeast-2`
+**To add organization secrets:**
+1. Go to organization **Settings → Secrets and variables → Actions**
+2. Click on **New organization secret**
+3. Add each secret with appropriate value
+4. Set repository access to either "All repositories" or select specific repositories
 
-**To add secrets:**
-1. Go to repository **Settings → Environments**
-2. Click on environment name
-3. Add environment secrets under **Environment secrets**
+### 3.3 Configure Organization Variables
 
-### 3.3 Configure Environment Variables
+**Create the following organization variables:**
+- `DEMO_R53_ZONE_NAME`: `demo.tak.nz`
+- `DEMO_STACK_NAME`: `Demo`
+- `DEMO_TEST_DURATION`: `300`
 
-**For `demo` environment:**
-1. Go to repository **Settings → Environments**
-2. Click on **demo** environment
-3. Add environment variables under **Environment variables**:
-   - `DEMO_TEST_DURATION`: `300`
-   - `STACK_NAME`: `Demo`
-   - `R53_ZONE_NAME`: `demo.tak.nz`
+**To add organization variables:**
+1. Go to organization **Settings → Secrets and variables → Actions**
+2. Click on **Variables** tab
+3. Click on **New organization variable**
+4. Add each variable with appropriate value
+5. Set repository access to either "All repositories" or select specific repositories
 
 > **Note:** Use variables (not secrets) for non-sensitive configuration like stack names and public domain names. Variables are visible in workflow logs, making debugging easier.
 


### PR DESCRIPTION
## Changes
- Updated GitHub OIDC setup documentation to use organization secrets and variables
- Added wildcard entry (`repo:TAK-NZ/etl-*:environment:demo/production`) for ETL repositories in both environments
- Updated GitHub workflow files to use organization-level configuration instead of environment-specific settings

## Benefits
- Centralized credential management at the organization level
- Simplified configuration across multiple repositories
- Easier maintenance of shared configuration values
- Support for wildcard repository patterns for ETL repositories

## Testing
- Verified that all references to environment secrets/variables have been replaced
- Confirmed that the documentation accurately reflects the new setup process
