### PR TITLE
Remove ETL Image Lifecycle Policies

### DIFF
--- a/lib/constructs/services.ts
+++ b/lib/constructs/services.ts
@@ -54,10 +54,10 @@ export function createEcrResources(scope: Construct, stackName: string, imageRet
     encryption: ecr.RepositoryEncryption.KMS,
     encryptionKey: kmsKey,
     lifecycleRules: [
-      { tagPrefixList: ['etl-adsbx-'], maxImageCount: imageRetentionCount },
-      { tagPrefixList: ['etl-earthquakes-'], maxImageCount: imageRetentionCount },
-      { tagPrefixList: ['etl-geojson-'], maxImageCount: imageRetentionCount },
-      { tagPrefixList: ['etl-inreach-'], maxImageCount: imageRetentionCount },
+      // { tagPrefixList: ['etl-adsbx-'], maxImageCount: imageRetentionCount },
+      // { tagPrefixList: ['etl-earthquakes-'], maxImageCount: imageRetentionCount },
+      // { tagPrefixList: ['etl-geojson-'], maxImageCount: imageRetentionCount },
+      // { tagPrefixList: ['etl-inreach-'], maxImageCount: imageRetentionCount },
       { tagStatus: ecr.TagStatus.UNTAGGED, maxImageAge: cdk.Duration.days(1) }
     ],
     removalPolicy: removalPolicy === 'RETAIN' ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY,


### PR DESCRIPTION
## Summary
This PR removes the ECR lifecycle rules for ETL task images in the ETL tasks repository. The rules have been commented out rather than deleted to make it easy to restore them if needed in the future.

## Why
- Ensures all ETL task images are retained indefinitely
- Prevents newly added ETL tasks from being unexpectedly affected by image cleanup
- Maintains historical versions of ETL tasks for debugging and rollback purposes

## Impact
- Increased storage usage in ECR repository (minimal cost impact)
- All ETL task images will be preserved indefinitely
- Only untagged images will still be automatically removed after 1 day

## Testing
Verified that the lifecycle rules are properly commented out and will not be applied when the infrastructure is deployed.
