### PR TITLE
Add MediaMTX Image Prefix to ECR Lifecycle Rules

### DIFF
--- a/lib/constructs/services.ts
+++ b/lib/constructs/services.ts
@@ -32,6 +32,7 @@ export function createEcrResources(scope: Construct, stackName: string, imageRet
       { tagPrefixList: ['events-'], maxImageCount: imageRetentionCount },
       { tagPrefixList: ['data-'], maxImageCount: imageRetentionCount },
       { tagPrefixList: ['cloudtak-'], maxImageCount: imageRetentionCount },
+      { tagPrefixList: ['mediamtx-'], maxImageCount: imageRetentionCount },
       { tagStatus: ecr.TagStatus.UNTAGGED, maxImageAge: cdk.Duration.days(1) }
     ],
     removalPolicy: removalPolicy === 'RETAIN' ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY,


### PR DESCRIPTION
## Changes
- **ECR lifecycle**: Added `mediamtx-` prefix to tag-based retention rules
- **Consistency**: MediaMTX images now follow same retention policy as other apps
- **Image management**: Ensures proper cleanup of MediaMTX container images

## Impact
MediaMTX container images will be retained according to the configured `imageRetentionCount` setting, matching the behavior of other application images.

## Breaking Changes
None - additive change only.
