### PR TITLE
Fix: Resolve js-yaml prototype pollution vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3310,9 +3310,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
This PR fixes a moderate severity security vulnerability in the `js-yaml` dependency by upgrading it from version 3.14.1 to 3.14.2.

## Issue
- **Vulnerability**: Prototype pollution in js-yaml merge (`<<`) functionality
- **Severity**: Moderate
- **CVE**: GHSA-mh29-5h37-fv8m
- **Affected versions**: js-yaml < 3.14.2
- **Impact**: Potential for attackers to modify the prototype of parsed YAML documents

## Changes
- Ran `npm audit fix` to automatically resolve the vulnerability
- Updated transitive dependency `js-yaml` from 3.14.1 → 3.14.2
- 21 packages updated in total as part of the dependency resolution

## Verification
- ✅ `npm audit` now reports 0 vulnerabilities
- ✅ js-yaml version confirmed upgraded to 3.14.2
- ✅ No breaking changes (patch version update only)