### PR TITLE
fix: update aws-cdk-lib to resolve bundled brace-expansion DoS alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@tak-nz/base-infra",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "^2.173.4",
+        "aws-cdk-lib": "^2.249.0",
         "constructs": "^10.4.2"
       },
       "bin": {
@@ -19,16 +19,16 @@
         "@swc/jest": "^0.2.37",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.10.2",
-        "aws-cdk": "^2.173.4",
+        "aws-cdk": "^2.1118.0",
         "jest": "^29.7.0",
         "ts-node": "^10.9.2",
         "typescript": "~5.7.2"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.263",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.263.tgz",
-      "integrity": "sha512-X9JvcJhYcb7PHs8R7m4zMablO5C9PGb/hYfLnxds9h/rKJu6l7MiXE/SabCibuehxPnuO/vk+sVVJiUWrccarQ==",
+      "version": "2.2.273",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
+      "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
@@ -38,9 +38,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "52.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-52.2.0.tgz",
-      "integrity": "sha512-ourZjixQ/UfsZc7gdk3vt1eHBODMUjQTYYYCY3ZX8fiXyHtWNDAYZPrXUK96jpCC2fLP+tfHTJrBjZ563pmcEw==",
+      "version": "53.14.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.14.0.tgz",
+      "integrity": "sha512-prx2sbFfKrVf3NNXMOmWq6lsIBeWQDIqMTILLAddGiidn9j7OnLUubknWpJlLozMveTvQELdI++nUwq6jwCm9g==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -48,7 +48,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "~1.4.1",
-        "semver": "^7.7.3"
+        "semver": "^7.7.4"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -63,7 +63,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.7.4",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -1600,9 +1600,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1109.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1109.0.tgz",
-      "integrity": "sha512-K0jvr5ne9kvDrFfdzbPee/s2rH/iXdGoMHTp/0jaj1qFMOh49RkLWTnURa0sBpJJ0uB2sMzIx7YRmAn55wAy1Q==",
+      "version": "2.1118.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1118.0.tgz",
+      "integrity": "sha512-Tfd865GRewDTXIbTVtix/l+v8t3rZENvdHcQQZS2wXYVXfHzljULFXe9JKkgZUNDPB1zo9tSBUu8jjiHRm7nWg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1613,9 +1613,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.241.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.241.0.tgz",
-      "integrity": "sha512-v0uDNDqJt6oJ/ZHRp+KIn4xzhF518uKpZxY8fi12bO+dt505t6fCqCaqXuadznokrAyWwIae6q3ByWJfmZzQjA==",
+      "version": "2.249.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.249.0.tgz",
+      "integrity": "sha512-SRb6TpPtsaywyoihMAYKBKB6O4RwSKK4VMLZwZF4xAJ+bBv5TaQKyXw4gQvoktLvCs1Bnluci0F66VBMD4bIRw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -1632,10 +1632,10 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.263",
+        "@aws-cdk/asset-awscli-v1": "2.2.273",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.1.1",
-        "@aws-cdk/cloud-assembly-schema": "^52.1.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.0",
+        "@aws-cdk/cloud-assembly-schema": "^53.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -1646,17 +1646,17 @@
         "punycode": "^2.3.1",
         "semver": "^7.7.4",
         "table": "^6.9.0",
-        "yaml": "1.10.2"
+        "yaml": "1.10.3"
       },
       "engines": {
-        "node": ">= 18.0.0"
+        "node": ">= 20.0.0"
       },
       "peerDependencies": {
         "constructs": "^10.5.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.1.1",
+      "version": "2.2.0",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -1665,13 +1665,13 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "~1.4.1",
-        "semver": "^7.7.3"
+        "semver": "^7.7.4"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=52.1.0"
+        "@aws-cdk/cloud-assembly-schema": ">=53.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
@@ -1683,7 +1683,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.7.4",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -1752,7 +1752,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.3",
+      "version": "5.0.5",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1894,11 +1894,11 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "10.2.4",
+      "version": "10.2.5",
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -1998,7 +1998,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
-      "version": "1.10.2",
+      "version": "1.10.3",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -4166,7 +4166,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@swc/jest": "^0.2.37",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.2",
-    "aws-cdk": "^2.173.4",
+    "aws-cdk": "^2.1118.0",
     "jest": "^29.7.0",
     "ts-node": "^10.9.2",
     "typescript": "~5.7.2"
@@ -40,7 +40,7 @@
     "picomatch": "^4.0.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.173.4",
+    "aws-cdk-lib": "^2.249.0",
     "constructs": "^10.4.2"
   }
 }


### PR DESCRIPTION
Upgrade aws-cdk-lib 2.241.0 -> 2.249.0 and aws-cdk 2.1109.0 -> 2.1118.0. aws-cdk-lib 2.249.0 bundles minimatch 10.2.5 which requires brace-expansion >=5.0.5, fixing GHSA-f886-m6hf-6m8v.

npm audit now reports 0 vulnerabilities.