### PR TITLE
fix(ecr): add utils-display-proxy- lifecycle rule

### DIFF
--- a/lib/constructs/services.ts
+++ b/lib/constructs/services.ts
@@ -38,6 +38,7 @@ export function createEcrResources(scope: Construct, stackName: string, imageRet
       { tagPrefixList: ['utils-ais-proxy-'], maxImageCount: imageRetentionCount },
       { tagPrefixList: ['utils-power-outages-'], maxImageCount: imageRetentionCount },
       { tagPrefixList: ['utils-terrain-proxy-'], maxImageCount: imageRetentionCount },
+      { tagPrefixList: ['utils-display-proxy-'], maxImageCount: imageRetentionCount },
       { tagStatus: ecr.TagStatus.UNTAGGED, maxImageAge: cdk.Duration.days(1) }
     ],
     removalPolicy: removalPolicy === 'RETAIN' ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY,


### PR DESCRIPTION
## What

Adds a dedicated ECR lifecycle rule for `utils-display-proxy-` images to match the new `display-proxy` container introduced in `utils-infra`.

```ts
{ tagPrefixList: ['utils-display-proxy-'], maxImageCount: imageRetentionCount },
```

## Why

Without this rule, `display-proxy` images pushed to the ECR artifacts repo have no retention policy. They also won't be protected from eviction if the total `utils-*` image count were ever consolidated back into a catch-all rule in the future.

This follows the per-service pattern established in #82 — each utils service owns its own lifecycle rule with an independent retention count.

## Testing

- `npm run build` — clean
- `npm test` — 11/11 suites, 37/37 tests