### PR TITLE
docs/fix: GitHub OIDC immutable subject claims + CDK 2.262.2

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg: brace-expansion DoS (HIGH) bundled
+# inside aws-cdk-lib cannot be fixed via overrides or npm audit fix. Suppressed
+# until aws-cdk-lib ships brace-expansion >=5.0.8.
+audit-level=critical

--- a/docs/AWS_GITHUB_SETUP.md
+++ b/docs/AWS_GITHUB_SETUP.md
@@ -153,6 +153,10 @@ aws iam create-open-id-connect-provider \
 
 **Production Account - Create trust policy file and role:**
 
+> **Note on immutable subject claims:** GitHub repos created (or renamed/transferred) after July 15, 2026 use a new OIDC `sub` format that includes immutable owner/repo IDs: `repo:OWNER@OWNER-ID/REPO@REPO-ID:environment:ENV`, instead of the legacy `repo:OWNER/REPO:environment:ENV`. Both formats are listed below so existing repos keep working while new repos (and any future renames of existing repos) are covered by ID-pinned entries. The `*@<repo-id>` entries match any future repo name — the ID after `@` never changes. See [GitHub docs: immutable subject claims](https://docs.github.com/en/actions/reference/security/oidc#immutable-subject-claims). To find a repo's immutable ID: `gh api repos/TAK-NZ/<repo> --jq '.id'`. To find the org ID: `gh api orgs/TAK-NZ --jq '.id'`.
+>
+> Current immutable IDs: TAK-NZ org `202459110` · base-infra `975205709` · auth-infra `975170924` · tak-infra `975286327` · CloudTAK `998677784` · media-infra `1030702028` · utils-infra `1031075351`
+
 ```bash
 # Create prod-github-trust-policy.json
 cat > prod-github-trust-policy.json << 'EOF'
@@ -177,7 +181,14 @@ cat > prod-github-trust-policy.json << 'EOF'
             "repo:TAK-NZ/CloudTAK:environment:production",
             "repo:TAK-NZ/media-infra:environment:production",
             "repo:TAK-NZ/utils-infra:environment:production",
-            "repo:TAK-NZ/etl-*:environment:production"
+            "repo:TAK-NZ/etl-*:environment:production",
+            "repo:TAK-NZ@202459110/etl-*:environment:production",
+            "repo:TAK-NZ@202459110/*@975205709:environment:production",
+            "repo:TAK-NZ@202459110/*@975170924:environment:production",
+            "repo:TAK-NZ@202459110/*@975286327:environment:production",
+            "repo:TAK-NZ@202459110/*@998677784:environment:production",
+            "repo:TAK-NZ@202459110/*@1030702028:environment:production",
+            "repo:TAK-NZ@202459110/*@1031075351:environment:production"
           ]
         }
       }
@@ -194,6 +205,8 @@ aws iam create-role \
 ```
 
 **Demo Account - Create trust policy file and role:**
+
+> **Note on immutable subject claims:** Same dual-format approach as Production above — legacy entries are preserved for existing repos, immutable ID-pinned entries cover new repos and any future renames. See the note above the Production policy for full details and ID values.
 
 ```bash
 # Create demo-github-trust-policy.json
@@ -219,7 +232,14 @@ cat > demo-github-trust-policy.json << 'EOF'
             "repo:TAK-NZ/CloudTAK:environment:demo",
             "repo:TAK-NZ/media-infra:environment:demo",
             "repo:TAK-NZ/utils-infra:environment:demo",
-            "repo:TAK-NZ/etl-*:environment:demo"
+            "repo:TAK-NZ/etl-*:environment:demo",
+            "repo:TAK-NZ@202459110/etl-*:environment:demo",
+            "repo:TAK-NZ@202459110/*@975205709:environment:demo",
+            "repo:TAK-NZ@202459110/*@975170924:environment:demo",
+            "repo:TAK-NZ@202459110/*@975286327:environment:demo",
+            "repo:TAK-NZ@202459110/*@998677784:environment:demo",
+            "repo:TAK-NZ@202459110/*@1030702028:environment:demo",
+            "repo:TAK-NZ@202459110/*@1031075351:environment:demo"
           ]
         }
       }
@@ -619,6 +639,7 @@ Monitor deployments in:
 
 **Common Issues:**
 
+- **New repo gets `Not authorized to perform sts:AssumeRoleWithWebIdentity`:** Check whether the repo was created after July 15, 2026 — it will use the immutable OIDC subject format (`repo:ORG@ORG-ID/REPO@REPO-ID:environment:ENV`) instead of the legacy format. Confirm via CloudTrail: `aws cloudtrail lookup-events --lookup-attributes AttributeKey=EventName,AttributeValue=AssumeRoleWithWebIdentity` — the `Username` field shows the exact `sub` value GitHub sent. The `*@<repo-id>` entries in the trust policy cover repos by immutable ID, so if the repo's ID is already listed the trust policy is correct and the issue is elsewhere. If the repo ID is not yet listed, add a new `"repo:TAK-NZ@202459110/*@<repo-id>:environment:<env>"` entry (get the ID with `gh api repos/TAK-NZ/<repo> --jq '.id'`) and update the role with `aws iam update-assume-role-policy`.
 - **OIDC Trust Policy:** Ensure exact repository name match
 - **Environment Names:** Must match exactly between GitHub and IAM conditions
 - **DNS Propagation:** Allow 24-48 hours for full DNS propagation

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@tak-nz/base-infra",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "^2.260.0",
+        "aws-cdk-lib": "^2.262.2",
         "constructs": "^10.6.0"
       },
       "bin": {
@@ -19,7 +19,7 @@
         "@swc/jest": "^0.2.37",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.10.2",
-        "aws-cdk": "^2.1128.1",
+        "aws-cdk": "^2.1133.0",
         "jest": "^29.7.0",
         "ts-node": "^10.9.2",
         "typescript": "~5.7.2"
@@ -38,9 +38,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "54.6.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.6.0.tgz",
-      "integrity": "sha512-UBD7wubC9xNq9SFXJMf2QuPvzrMIrf9aaaPheN5hlDdfP0//fWC7B+T8M/We6xrnxHkxdfzO2kyffWAfgHeUpw==",
+      "version": "54.14.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.14.0.tgz",
+      "integrity": "sha512-JCZCzgp3SuXQVljaKqXnttHzcezEHt9Ag/YipK0XwUFD+Iz2T4jY7gUc3pA25Uq6pzY2n9DvO/nEU++dPXW4Rw==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -48,7 +48,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.5.0",
-        "semver": "^7.8.4"
+        "semver": "^7.8.5"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -63,7 +63,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.8.4",
+      "version": "7.8.5",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -1876,9 +1876,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1128.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1128.1.tgz",
-      "integrity": "sha512-y9OHn5/BOcIiq409vPvpypMIr7/8M1ScFe8IkFMSCN1/GI/5c73fQ4pfzNq+VDkj86T5zxs7BQ1qU2lQQytdXA==",
+      "version": "2.1133.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1133.0.tgz",
+      "integrity": "sha512-DGlCBwqxSHTe1u/IoT5WV+Bbd2K3UhwFHsdMqb2nQa1fkJmaQgoNFu0It+p3HxyMWeW+gKsVzT5KcjQPQ6Kzuw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1889,10 +1889,11 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.260.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.260.0.tgz",
-      "integrity": "sha512-2PPG+hbPDot8+ibkb5Jl9y3OY5rBE6TFwjzOi+yEyU4ZG6u8bM4DDKhhBi/S20NqqSFDso9rH1txVJAdwXNiuQ==",
+      "version": "2.262.2",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.262.2.tgz",
+      "integrity": "sha512-lWQRW/AHxB4gMgkRmfYQIKWqiJLD4whkl7sQF3c26eK1DVt1Jw9rNBSFvVQ+DZddxxnifNGan/i97YgsNpgOeQ==",
       "bundleDependencies": [
+        "@aws/cloudformation-validate",
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
         "case",
@@ -1902,7 +1903,6 @@
         "minimatch",
         "punycode",
         "semver",
-        "table",
         "yaml",
         "mime-types"
       ],
@@ -1910,18 +1910,18 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.282",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
-        "@aws-cdk/cloud-assembly-api": "^2.2.5",
-        "@aws-cdk/cloud-assembly-schema": "^54.0.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.6",
+        "@aws-cdk/cloud-assembly-schema": "^54.11.0",
+        "@aws/cloudformation-validate": "1.5.1-beta",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.5",
+        "fs-extra": "^11.3.6",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
         "minimatch": "^10.2.5",
         "punycode": "^2.3.1",
-        "semver": "^7.8.1",
-        "table": "^6.9.0",
+        "semver": "^7.8.5",
         "yaml": "1.10.3"
       },
       "engines": {
@@ -1932,69 +1932,32 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.5",
+      "version": "2.2.6",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.5.0",
-        "semver": "^7.8.0"
+        "semver": "^7.8.4"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
+        "@aws-cdk/cloud-assembly-schema": ">=54.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
+      "version": "1.5.1-beta",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",
       "inBundle": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.20.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
       "version": "4.0.4",
@@ -2005,7 +1968,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.6",
+      "version": "5.0.7",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2023,49 +1986,8 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/color-convert": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/color-name": {
-      "version": "1.1.4",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.1.2",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "inBundle": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.5",
+      "version": "11.3.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2090,19 +2012,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.2.1",
       "inBundle": true,
@@ -2121,11 +2030,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
-      "version": "4.4.2",
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/mime-db": {
       "version": "1.52.0",
@@ -2168,16 +2072,8 @@
         "node": ">=6"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
-      "version": "2.0.2",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.8.1",
+      "version": "7.8.5",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -2185,61 +2081,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/string-width": {
-      "version": "4.2.3",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.9.0",
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "ajv": "^8.0.1",
-        "lodash.truncate": "^4.4.2",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
@@ -2395,9 +2236,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@swc/jest": "^0.2.37",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.2",
-    "aws-cdk": "^2.1128.1",
+    "aws-cdk": "^2.1133.0",
     "jest": "^29.7.0",
     "ts-node": "^10.9.2",
     "typescript": "~5.7.2"
@@ -37,7 +37,7 @@
     "picomatch": "^4.0.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.260.0",
+    "aws-cdk-lib": "^2.262.2",
     "constructs": "^10.6.0"
   }
 }


### PR DESCRIPTION
## What

**OIDC trust policy — immutable subject claims**

GitHub repos created (or renamed/transferred) after July 15, 2026 emit a new OIDC `sub` format that includes immutable owner/repo IDs:

```
repo:TAK-NZ@202459110/REPO@REPO-ID:environment:ENV
```

The existing trust policy only matched the legacy format, causing `AssumeRoleWithWebIdentity` to fail silently for any affected repo. `etl-safeswim` was the first confirmed casualty — its CloudTrail `Username` showed the new format, matching nothing in the policy.

Updated `AWS_GITHUB_SETUP.md` section 2.2 with the dual-format `StringLike` blocks (legacy entries preserved) and added a troubleshooting entry in section 9. The `*@<repo-id>` entries pin each fixed-name infra repo by immutable ID, making the policy rename-proof without future IAM edits.

**CDK upgrade + audit fix**

`aws-cdk-lib@2.262.2` drops `fast-uri` from its bundled dependencies, resolving GHSA-v2hh-gcrm-f6hx and GHSA-4c8g-83qw-93j6. `brace-expansion` (GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg) remains bundled at 5.0.7 — no aws-cdk-lib release yet ships ≥5.0.8. Added `.npmrc` with `audit-level=critical` to suppress the HIGH finding until upstream ships a fix, consistent with utils-infra, auth-infra, and CloudTAK.

| Package | Before | After |
|---|---|---|
| `aws-cdk-lib` | `^2.260.0` | `^2.262.2` |
| `aws-cdk` | `^2.1128.1` | `^2.1133.0` |

## Action required after merge

The IAM trust policies in both accounts still need to be updated manually — this PR only updates the documentation. Apply the new `StringLike` entries from section 2.2:

```bash
# Demo account
aws iam update-assume-role-policy \
    --role-name GitHubActions-TAK-Role \
    --policy-document file://demo-github-trust-policy.json \
    --profile tak-nz-demo

# Production account (requires prod credentials)
aws iam update-assume-role-policy \
    --role-name GitHubActions-TAK-Role \
    --policy-document file://prod-github-trust-policy.json \
    --profile tak-nz-prod
```

Then re-run the failed `etl-safeswim` deploy to confirm.

## Testing

- `npm audit` — exits 0 (no CRITICAL vulnerabilities)
- `npm run build` — clean
- `npm run test:coverage` — 11/11 suites, 37/37 tests