### PR TITLE
chore: update CDK to latest and fix deprecation warnings

### DIFF
--- a/lib/constructs/vpc.ts
+++ b/lib/constructs/vpc.ts
@@ -66,7 +66,7 @@ function configureIpv6Subnets(
   const eigw = new ec2.CfnEgressOnlyInternetGateway(scope, 'EgressOnlyInternetGateway', {
     vpcId: vpc.vpcId,    
   });
-  eigw.addDependency(ipv6CidrBlock);
+  eigw.addResourceDependency(ipv6CidrBlock);
 
   // Get Internet Gateway for public subnets (created by VPC construct)
   const internetGateway = vpc.node.findChild('IGW') as ec2.CfnInternetGateway;
@@ -82,7 +82,7 @@ function configureIpv6Subnets(
       '64' // IPv6 subnet size
     ));
     subnetCfn.assignIpv6AddressOnCreation = true;
-    subnetCfn.addDependency(ipv6CidrBlock);
+    subnetCfn.addResourceDependency(ipv6CidrBlock);
 
     // Add IPv6 route to Internet Gateway
     const ipv6Route = new ec2.CfnRoute(scope, `PublicSubnetIpv6Route${index}`, {
@@ -90,8 +90,8 @@ function configureIpv6Subnets(
       destinationIpv6CidrBlock: '::/0',
       gatewayId: internetGateway.ref,
     });
-    ipv6Route.addDependency(internetGateway);
-    ipv6Route.addDependency(ipv6CidrBlock);
+    ipv6Route.addResourceDependency(internetGateway);
+    ipv6Route.addResourceDependency(ipv6CidrBlock);
   });
 
   // Configure private subnets for IPv6
@@ -105,7 +105,7 @@ function configureIpv6Subnets(
       '64' // IPv6 subnet size
     ));
     subnetCfn.assignIpv6AddressOnCreation = true;
-    subnetCfn.addDependency(ipv6CidrBlock);
+    subnetCfn.addResourceDependency(ipv6CidrBlock);
 
     // Add IPv6 route to Egress-Only Internet Gateway
     const ipv6Route = new ec2.CfnRoute(scope, `PrivateSubnetIpv6Route${index}`, {
@@ -113,7 +113,7 @@ function configureIpv6Subnets(
       destinationIpv6CidrBlock: '::/0',
       egressOnlyInternetGatewayId: eigw.ref,
     });
-    ipv6Route.addDependency(eigw);
-    ipv6Route.addDependency(ipv6CidrBlock);
+    ipv6Route.addResourceDependency(eigw);
+    ipv6Route.addResourceDependency(ipv6CidrBlock);
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@tak-nz/base-infra",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "^2.262.2",
-        "constructs": "^10.6.0"
+        "aws-cdk-lib": "^2.263.0",
+        "constructs": "^10.8.0"
       },
       "bin": {
         "cdk": "bin/cdk.js"
@@ -19,7 +19,7 @@
         "@swc/jest": "^0.2.37",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.10.2",
-        "aws-cdk": "^2.1133.0",
+        "aws-cdk": "^2.1134.0",
         "jest": "^29.7.0",
         "ts-node": "^10.9.2",
         "typescript": "~5.7.2"
@@ -1876,9 +1876,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1133.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1133.0.tgz",
-      "integrity": "sha512-DGlCBwqxSHTe1u/IoT5WV+Bbd2K3UhwFHsdMqb2nQa1fkJmaQgoNFu0It+p3HxyMWeW+gKsVzT5KcjQPQ6Kzuw==",
+      "version": "2.1134.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1134.0.tgz",
+      "integrity": "sha512-Fy/g+gdpMpkhAAoCNlZtX0s4mD7q58bHlDV6QfbnTeifmQ5cEge26c5rB+U4qKB/bDudxNuJjQk/mSSk0ysnug==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1889,9 +1889,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.262.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.262.2.tgz",
-      "integrity": "sha512-lWQRW/AHxB4gMgkRmfYQIKWqiJLD4whkl7sQF3c26eK1DVt1Jw9rNBSFvVQ+DZddxxnifNGan/i97YgsNpgOeQ==",
+      "version": "2.263.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.263.0.tgz",
+      "integrity": "sha512-cXC9wnOr+LknMee9x0kYwofgVs8aN8eBKsbzcE90sDUtpLTgWG2Bd+9koqxBKPeIU8kig/GGBFwJ69Wr+hLKDg==",
       "bundleDependencies": [
         "@aws/cloudformation-validate",
         "@balena/dockerignore",
@@ -1912,7 +1912,7 @@
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
         "@aws-cdk/cloud-assembly-api": "^2.2.6",
         "@aws-cdk/cloud-assembly-schema": "^54.11.0",
-        "@aws/cloudformation-validate": "1.5.1-beta",
+        "@aws/cloudformation-validate": "1.6.0-beta",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.6",
@@ -1947,7 +1947,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
-      "version": "1.5.1-beta",
+      "version": "1.6.0-beta",
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1968,14 +1968,14 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.7",
+      "version": "5.0.8",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/case": {
@@ -2454,9 +2454,9 @@
       "license": "MIT"
     },
     "node_modules/constructs": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz",
-      "integrity": "sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.8.0.tgz",
+      "integrity": "sha512-pJHp2CxvTG0ttp52rZvQfkbspPLZzttWPooIRLBwlZK8rV7ZhkjIkyZWJhIfBDC4YdcwIDmXyUFr1ieJaqjBbg==",
       "license": "Apache-2.0"
     },
     "node_modules/convert-source-map": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@swc/jest": "^0.2.37",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.2",
-    "aws-cdk": "^2.1133.0",
+    "aws-cdk": "^2.1134.0",
     "jest": "^29.7.0",
     "ts-node": "^10.9.2",
     "typescript": "~5.7.2"
@@ -37,7 +37,7 @@
     "picomatch": "^4.0.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.262.2",
-    "constructs": "^10.6.0"
+    "aws-cdk-lib": "^2.263.0",
+    "constructs": "^10.8.0"
   }
 }


### PR DESCRIPTION
## Summary
- Updated `aws-cdk` to 2.1134.0, `aws-cdk-lib` to 2.263.0, and `constructs` to 10.8.0
- Replaced deprecated `CfnResource#addDependency` calls with `addResourceDependency` in `lib/constructs/vpc.ts` to remove deprecation warnings surfaced by the CDK version bump

## Details
The `addDependency` API on `CfnResource` is deprecated in favor of `addResourceDependency` and will be removed in a future major CDK release. This surfaced as repeated warnings during `npm run test:coverage`. All 6 call sites in the IPv6 subnet/routing configuration were updated.

## Testing
- `npm run build` — passes
- `npm run test` — 11 suites, 37 tests passing
- `npm run test:coverage` — 11 suites, 37 tests passing, no deprecation warnings, coverage unchanged (98% stmts / 100% branch/func/line)

## Blocked features
None.
